### PR TITLE
Fix for Julia 0.4. with regenerated c-bindings via Clang.jl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - osx
     - linux
 julia:
-    - 0.3
     - 0.4
     - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.4-
 BinDeps 0.3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.3/julia-0.3-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.3/julia-0.3-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -35,13 +35,13 @@ provides(SimpleBuild,
     end), sundialslibs)
 
 if enable_sensitivities
-@BinDeps.install [:libsundials_cvodes => :libsundials_cvodes,
+@BinDeps.install Dict(:libsundials_cvodes => :libsundials_cvodes,
                   :libsundials_idas => :libsundials_idas,
                   :libsundials_kinsol => :libsundials_kinsol,
-                  :libsundials_nvecserial => :libsundials_nvecserial]
+                  :libsundials_nvecserial => :libsundials_nvecserial)
 else
-@BinDeps.install [:libsundials_cvode => :libsundials_cvode,
+@BinDeps.install Dict(:libsundials_cvode => :libsundials_cvode,
                   :libsundials_ida => :libsundials_ida,
                   :libsundials_kinsol => :libsundials_kinsol,
-                  :libsundials_nvecserial => :libsundials_nvecserial]
+                  :libsundials_nvecserial => :libsundials_nvecserial)
 end

--- a/examples/cvode_Roberts_dns.jl
+++ b/examples/cvode_Roberts_dns.jl
@@ -9,7 +9,7 @@ function f(t, y, ydot, user_data)
     ydot[1] = -0.04*y[1] + 1.0e4*y[2]*y[3]
     ydot[3] = 3.0e7*y[2]*y[2]
     ydot[2] = -ydot[1] - ydot[3]
-    return int32(0)
+    return Int32(0)
 end
 
 
@@ -20,7 +20,7 @@ function g(t, y, gout, user_data)
     gout = Sundials.asarray(gout, (2,))
     gout[1] = y[1] - 0.0001
     gout[2] = y[3] - 0.01
-    return int32(0)
+    return Int32(0)
 end
 
 ## Jacobian routine. Compute J(t,y) = df/dy.  
@@ -62,7 +62,7 @@ end
 function Jac(N, t, y, fy, Jptr, user_data,
              tmp1, tmp2, tmp3)
     y = Sundials.asarray(y)
-    dlsmat = unpack(IOString(pointer_to_array(convert(Ptr{Uint8}, Jptr),
+    dlsmat = unpack(IOString(pointer_to_array(convert(Ptr{UInt8}, Jptr),
                                               (sum(map(sizeof, J_DlsMat.types))+10,))),
                     J_DlsMat)
     J = pointer_to_array(unsafe_ref(dlsmat.cols), (int(neq), int(neq)), false)
@@ -73,10 +73,10 @@ function Jac(N, t, y, fy, Jptr, user_data,
     J[2,2] = -1.0e4*y[3] - 6.0e7*y[2]
     J[2,3] = -1.0e4*y[2]
     J[3,2] = 6.0e7*y[2]
-    return int32(0)
+    return Int32(0)
 end
 
-neq = int32(3)
+neq = Int32(3)
 
 t0 = 0.0
 t1 = 0.4
@@ -89,14 +89,14 @@ abstol = [1e-8, 1e-14, 1e-6]
 cvode_mem = Sundials.CVodeCreate(Sundials.CV_BDF, Sundials.CV_NEWTON)
 flag = Sundials.CVodeInit(cvode_mem, f, t0, y)
 flag = Sundials.CVodeSVtolerances(cvode_mem, reltol, abstol)
-flag = Sundials.CVodeRootInit(cvode_mem, int32(2), g)
+flag = Sundials.CVodeRootInit(cvode_mem, Int32(2), g)
 flag = Sundials.CVDense(cvode_mem, neq)
 ## flag = Sundials.CVDlsSetDenseJacFn(cvode_mem, Jac)  # works, but clunky, see above
 
 iout = 0
 tout = t1
 
-rootsfound = int32([0, 0])
+rootsfound = round(Int32,[0, 0])
 t = [t0]
 
 while true

--- a/examples/cvode_Roberts_simplified.jl
+++ b/examples/cvode_Roberts_simplified.jl
@@ -6,6 +6,7 @@ function f(t, y, ydot)
     ydot[1] = -0.04*y[1] + 1.0e4*y[2]*y[3]
     ydot[3] = 3.0e7*y[2]*y[2]
     ydot[2] = -ydot[1] - ydot[3]
+    return(Int32(0))
 end
-t = [0.0, 4 * logspace(-1., 7., 9)]
+t = [0.0; 4 * logspace(-1., 7., 9)]
 res = Sundials.cvode(f, [1.0, 0.0, 0.0], t)

--- a/examples/ida_Cable.jl
+++ b/examples/ida_Cable.jl
@@ -19,7 +19,7 @@ L = 4000
 
 ## Number of space steps to simulate
 dx = 10
-xsteps = int(L/dx)
+xsteps = round(Int,L/dx)
 
 ## Number of timesteps to simulate
 tf = 10.0
@@ -69,7 +69,7 @@ function cableres(t, u, up, r)
 end
 
 
-function initial ()
+function initial()
 
     u = zeros(xsteps)
 
@@ -77,8 +77,8 @@ function initial ()
     
     id = ones(xsteps)
 
-    up = zeros (xsteps)
-    r  = zeros (xsteps)
+    up = zeros(xsteps)
+    r  = zeros(xsteps)
 
     cableres(0.0, u, up, r)
 
@@ -97,23 +97,23 @@ function idabandsol(f::Function, y0::Vector{Float64}, yp0::Vector{Float64},
     neq = length(y0)
     mem = Sundials.IDACreate()
     flag = Sundials.IDAInit(mem, cfunction(Sundials.idasolfun, Int32,
-                                           (Sundials.realtype, Sundials.N_Vector, Sundials.N_Vector, Sundials.N_Vector, Function)),
+                                           (Sundials.realtype, Sundials.N_Vector, Sundials.N_Vector, Sundials.N_Vector, Ref{Function})),
                             t[1], nvector(y0), nvector(yp0))
-    assert (flag == 0)
+    assert(flag == 0)
     flag = Sundials.IDASetId(mem,nvector(id))
-    assert (flag == 0)
+    assert(flag == 0)
     flag = Sundials.IDASetUserData(mem, f)
-    assert (flag == 0)
+    assert(flag == 0)
     flag = Sundials.IDASStolerances(mem, reltol, abstol)
-    assert (flag == 0)
+    assert(flag == 0)
     mu = xsteps-1
     ml = xsteps-1
     flag = Sundials.IDABand(mem, neq, mu, ml)
     ##flag = Sundials.IDADense(mem, neq)
-    assert (flag == 0)
+    assert(flag == 0)
     rtest = zeros(neq)
     flag = Sundials.IDACalcIC(mem, Sundials.IDA_YA_YDP_INIT, t[2])
-    assert (flag == 0)
+    assert(flag == 0)
     yres = zeros(length(t), length(y0))
     ypres = zeros(length(t), length(y0))
     yres[1,:] = y0
@@ -129,7 +129,7 @@ function idabandsol(f::Function, y0::Vector{Float64}, yp0::Vector{Float64},
     return yres, ypres
 end
 
-u0, up0, id = initial ()
+u0, up0, id = initial()
 
 yout, ypout = @time idabandsol(cableres, u0, up0, id, map(x -> x, t),
                                reltol = 1e-3, abstol = 1e-4)

--- a/examples/ida_Heat2D.jl
+++ b/examples/ida_Heat2D.jl
@@ -61,12 +61,12 @@ function heatres(t, u, up, r)
 end
 
 
-function initial ()
+function initial()
 
     mm = MGRID
     mm1 = mm - 1
   
-    u  = zeros (NEQ)
+    u  = zeros(NEQ)
     id = ones(NEQ)
 
     ## initialize u on all grid points
@@ -80,8 +80,8 @@ function initial ()
         end
     end
 
-    up = zeros (NEQ)
-    r  = zeros (NEQ)
+    up = zeros(NEQ)
+    r  = zeros(NEQ)
 
     heatres(0.0, u, up, r)
 
@@ -115,24 +115,24 @@ function idabandsol(f::Function, y0::Vector{Float64}, yp0::Vector{Float64},
     neq = length(y0)
     mem = Sundials.IDACreate()
     flag = Sundials.IDAInit(mem, cfunction(Sundials.idasolfun, Int32,
-                                           (Sundials.realtype, Sundials.N_Vector, Sundials.N_Vector, Sundials.N_Vector, Function)),
+                                           (Sundials.realtype, Sundials.N_Vector, Sundials.N_Vector, Sundials.N_Vector, Ref{Function})),
                             t[1], nvector(y0), nvector(yp0))
-    assert (flag == 0)
+    assert(flag == 0)
     flag = Sundials.IDASetId(mem,nvector(id))
-    assert (flag == 0)
+    assert(flag == 0)
     flag = Sundials.IDASetConstraints(mem,nvector(constraints))
-    assert (flag == 0)
+    assert(flag == 0)
     flag = Sundials.IDASetUserData(mem, f)
-    assert (flag == 0)
+    assert(flag == 0)
     flag = Sundials.IDASStolerances(mem, reltol, abstol)
-    assert (flag == 0)
+    assert(flag == 0)
     mu = MGRID
     ml = MGRID
     flag = Sundials.IDABand(mem, neq, mu, ml)
-    assert (flag == 0)
+    assert(flag == 0)
     rtest = zeros(neq)
     flag = Sundials.IDACalcIC(mem, Sundials.IDA_YA_YDP_INIT, t[2])
-    assert (flag == 0)
+    assert(flag == 0)
     yres = zeros(length(t), length(y0))
     ypres = zeros(length(t), length(y0))
     yres[1,:] = y0
@@ -151,7 +151,7 @@ end
 nsteps = 10
 tstep = 0.005
 t = 0.0:tstep:(tstep*nsteps)
-u0, up0, id, constraints = initial ()
+u0, up0, id, constraints = initial()
 
 yout, ypout = idabandsol(heatres, u0, up0, id, constraints, map(x -> x, t),
                          reltol = 0.0, abstol = 1e-3)

--- a/examples/ida_Roberts_dns.jl
+++ b/examples/ida_Roberts_dns.jl
@@ -43,7 +43,7 @@ function resrob(tres, yy, yp, rr, user_data)
     rval[2]  = -rval[1] - 3.0e7*yval[2]*yval[2] - ypval[2]
     rval[1] -=  ypval[1]
     rval[3]  =  yval[1] + yval[2] + yval[3] - 1.0
-    return int32(0)   # indicates normal return
+    return Int32(0)   # indicates normal return
 end
 
 ## Root function routine. Compute functions g_i(t,y) for i = 0,1. 
@@ -52,7 +52,7 @@ function grob(t, yy, yp, gout, user_data)
     gval = Sundials.asarray(gout, (2,))
     gval[1] = yval[1] - 0.0001
     gval[2] = yval[3] - 0.01
-    return int32(0)   # indicates normal return
+    return Int32(0)   # indicates normal return
 end
 
 ## Define the Jacobian function. BROKEN - JJ is wrong
@@ -69,10 +69,10 @@ function jacrob(Neq, tt, cj, yy, yp, resvec,
     JJ[1,3] = 1.0e4*yval[2]
     JJ[2,3] = -1.0e4*yval[2]
     JJ[3,3] = 1.0
-    return int32(0)   # indicates normal return
+    return Int32(0)   # indicates normal return
 end
 
-neq = int32(3)
+neq = Int32(3)
 nout = 12
 t0 = 0.0
 yy = [1.0,0.0,0.0]
@@ -86,7 +86,7 @@ retval = Sundials.IDAInit(mem, resrob, t0, yy, yp)
 retval = Sundials.IDASVtolerances(mem, rtol, avtol)
 
 ## Call IDARootInit to specify the root function grob with 2 components
-retval = Sundials.IDARootInit(mem, int32(2), grob)
+retval = Sundials.IDARootInit(mem, Int32(2), grob)
 
 ## Call IDADense and set up the linear solver.
 retval = Sundials.IDADense(mem, neq)
@@ -95,7 +95,7 @@ retval = Sundials.IDADense(mem, neq)
 iout = 0
 tout = tout1
 tret = [1.0]
-rootsfound = int32([0, 0])
+rootsfound = round(Int32,[0, 0])
 
 while true 
     retval = Sundials.IDASolve(mem, tout, tret, yy, yp, Sundials.IDA_NORMAL)

--- a/examples/ida_Roberts_simplified.jl
+++ b/examples/ida_Roberts_simplified.jl
@@ -8,5 +8,5 @@ function resrob(tres, y, yp, r)
     r[3]  =  y[1] + y[2] + y[3] - 1.0
 end
 
-t = [0.0, 4 * logspace(-1., 5., 7)]
+t = [0.0; 4 * logspace(-1., 5., 7)]
 yout, ypout = Sundials.idasol(resrob, [1.0, 0, 0], [-0.04, 0.04, 0.0], t)

--- a/examples/kinsol_mkinTest.jl
+++ b/examples/kinsol_mkinTest.jl
@@ -18,7 +18,7 @@ function sysfn(y_in, fy_in, a_in)
     fy = Sundials.asarray(fy_in)
     fy[1] = y[1]^2 + y[2]^2 - 1.0
     fy[2] = y[2] - y[1]^2
-    return int32(0)   # indicates normal return
+    return Int32(0)   # indicates normal return
 end
 
 ## Initialize problem

--- a/src/Sundials.jl
+++ b/src/Sundials.jl
@@ -1,17 +1,10 @@
 module Sundials
-
-if isfile(joinpath(dirname(dirname(@__FILE__)),"deps","deps.jl"))
-    include("../deps/deps.jl")
+const depsfile = joinpath(dirname(dirname(@__FILE__)),"deps","deps.jl")
+if isfile(depsfile)
+    include(depsfile)
 else
     error("Sundials not properly installed. Please run Pkg.build(\"Sundials\")")
 end
- 
-##################################################################
-# Deprecations
-##################################################################
-
-@deprecate ode cvode
-@deprecate ida idasol
 
 
 ##################################################################
@@ -20,27 +13,45 @@ end
 #
 ##################################################################
 
+recurs_sym_type(ex::Any) = 
+  (ex==Union{} || typeof(ex)==Symbol || length(ex.args)==1) ? eval(ex) : Expr(ex.head, ex.args[1], recurs_sym_type(ex.args[2]))
+macro c(ret_type, func, arg_types, lib)
+  local _arg_types = Expr(:tuple, [recurs_sym_type(a) for a in arg_types.args]...)
+  local _ret_type = recurs_sym_type(ret_type)
+  local _args_in = Any[ symbol(string('a',x)) for x in 1:length(_arg_types.args) ]
+  local _lib = eval(lib)
+  quote
+    $(esc(func))($(_args_in...)) = ccall( ($(string(func)), $(Expr(:quote, _lib)) ), $_ret_type, $_arg_types, $(_args_in...) )
+  end
+end
+
+macro ctypedef(fake_t,real_t)
+  real_t = recurs_sym_type(real_t)
+  quote
+    typealias $fake_t $real_t
+  end
+end
+
 typealias __builtin_va_list Ptr{:Void}
 
 if isdefined(:libsundials_cvodes)
-    libsundials_cvode = libsundials_cvodes
-    libsundials_ida = libsundials_idas
+    const libsundials_cvode = libsundials_cvodes
+    const libsundials_ida = libsundials_idas
 end
 
-shlib = libsundials_nvecserial
+include("sundials_h.jl")
 include("nvector.jl")
-shlib = libsundials_cvode
 include("libsundials.jl")
-include("cvode.jl")
 if isdefined(:libsundials_cvodes)
-    shlib = libsundials_cvodes
     include("cvodes.jl")
+else
+    include("cvode.jl")
 end
 shlib = libsundials_ida
-include("ida.jl")
 if isdefined(:libsundials_cvodes)
-    shlib = libsundials_idas
     include("idas.jl")
+else
+    include("ida.jl")
 end
 shlib = libsundials_kinsol
 include("kinsol.jl")
@@ -125,9 +136,9 @@ CVodeQuadReInit(mem, yQ0::Vector{realtype}) =
 CVodeQuadSVtolerances(mem, reltolQ, abstolQ::Vector{realtype}) =
     CVodeQuadSVtolerances(mem, reltolQ, nvector(abstolQ))
 CVodeSensInit(mem, Ns, ism, fS::Function, yS0) =
-    CVodeSensInit(mem, Ns, ism, cfunction(fS, Int32, (int32, realtype, N_Vector, N_Vector, N_Vector, N_Vector, Ptr{Void}, N_Vector, N_Vector)), nvector(yS0))
+    CVodeSensInit(mem, Ns, ism, cfunction(fS, Int32, (Int32, realtype, N_Vector, N_Vector, N_Vector, N_Vector, Ptr{Void}, N_Vector, N_Vector)), yS0)
 CVodeSensInit1(mem, Ns, ism, fS1::Function, yS0) =
-    CVodeSensInit1(mem, Ns, ism, cfunction(fS1, Int32, (int32, realtype, N_Vector, N_Vector, int32, N_Vector, N_Vector, Ptr{Void}, N_Vector, N_Vector)), nvector(yS0))
+    CVodeSensInit1(mem, Ns, ism, cfunction(fS1, Int32, (Int32, realtype, N_Vector, N_Vector, Int32, N_Vector, N_Vector, Ptr{Void}, N_Vector, N_Vector)), yS0)
 CVodeSensReInit(mem, ism, yS0::Vector{realtype}) =
     CVodeSensReInit(mem, ism, nvector(yS0))
 CVodeSensSVtolerances(mem, reltolS, abstolS::Vector{realtype}) =
@@ -195,7 +206,7 @@ CVodeGetAdjDataPointPolynomial(mem, which, t, y::Vector{realtype}) =
 CVodeWFtolerances(mem, efun::Function) =
     CVodeWFtolerances(mem, cfunction(efun, Int32, (N_Vector, N_Vector, Ptr{Void})))
 CVodeSetErrHandlerFn(mem, ehfun::Function, eh_data) =
-    CVodeSetErrHandlerFn(mem, cfunction(ehfun, Void, (Int32, Ptr{Uint8}, Ptr{Uint8}, Ptr{Uint8}, Ptr{Void})), eh_data)
+    CVodeSetErrHandlerFn(mem, cfunction(ehfun, Void, (Int32, Ptr{UInt8}, Ptr{UInt8}, Ptr{UInt8}, Ptr{Void})), eh_data)
 
 # IDAS  (still incomplete)
 IDAReInit(mem, t0, yy0::Vector{realtype}, yp0::Vector{realtype}) =
@@ -216,13 +227,13 @@ end
 ##################################################################
 
 
-@c Int32 KINSetUserData (Ptr{:None},Any) libsundials_kinsol  ## needed to allow passing a Function through the user data
+@c Int32 KINSetUserData (Ptr{:Void},Any) libsundials_kinsol  ## needed to allow passing a Function through the user data
 
 function kinsolfun(y::N_Vector, fy::N_Vector, userfun::Function)
     y = asarray(y)
     fy = asarray(fy)
     userfun(y, fy)
-    return int32(0)
+    return Int32(0)
 end
 
 function kinsol(f::Function, y0::Vector{Float64})
@@ -234,7 +245,7 @@ function kinsol(f::Function, y0::Vector{Float64})
     kmem = KINCreate()
     # use the user_data field to pass a function
     #   see: https://github.com/JuliaLang/julia/issues/2554
-    flag = KINInit(kmem, cfunction(kinsolfun, Int32, (N_Vector, N_Vector, Function)), nvector(y0))
+    flag = KINInit(kmem, cfunction(kinsolfun, Int32, (N_Vector, N_Vector, Ref{Function})), nvector(y0))
     flag = KINDense(kmem, neq)
     flag = KINSetUserData(kmem, f)
     ## Solve problem
@@ -249,16 +260,17 @@ function kinsol(f::Function, y0::Vector{Float64})
     if flag != 0
         println("KINSol error found")
     end
+    KINFree([kmem])
     return y
 end
 
-@c Int32 CVodeSetUserData (Ptr{:None},Any) libsundials_cvode  ## needed to allow passing a Function through the user data
+@c Int32 CVodeSetUserData (Ptr{:Void},Any) libsundials_cvode  ## needed to allow passing a Function through the user data
 
 function cvodefun(t::Float64, y::N_Vector, yp::N_Vector, userfun::Function)
     y = Sundials.asarray(y)
     yp = Sundials.asarray(yp)
     userfun(t, y, yp)
-    return int32(0)
+    return Int32(0)
 end
 
 function cvode(f::Function, y0::Vector{Float64}, t::Vector{Float64}; reltol::Float64=1e-4, abstol::Float64=1e-6)
@@ -272,7 +284,7 @@ function cvode(f::Function, y0::Vector{Float64}, t::Vector{Float64}; reltol::Flo
     #         state variable `y` along columns
     neq = length(y0)
     mem = CVodeCreate(CV_BDF, CV_NEWTON)
-    flag = CVodeInit(mem, cfunction(cvodefun, Int32, (realtype, N_Vector, N_Vector, Function)), t[1], nvector(y0))
+    flag = CVodeInit(mem, cfunction(cvodefun, Int32, (realtype, N_Vector, N_Vector, Ref{Function})), t[1], nvector(y0))
     flag = CVodeSetUserData(mem, f)
     flag = CVodeSStolerances(mem, reltol, abstol)
     flag = CVDense(mem, neq)
@@ -284,17 +296,18 @@ function cvode(f::Function, y0::Vector{Float64}, t::Vector{Float64}; reltol::Flo
         flag = CVode(mem, t[k], y, tout, CV_NORMAL)
         yres[k,:] = y
     end
+    CVodeFree([mem])
     return yres
 end
 
-@c Int32 IDASetUserData (Ptr{:None},Any) libsundials_ida  ## needed to allow passing a Function through the user data
+@c Int32 IDASetUserData (Ptr{:Void},Any) libsundials_ida  ## needed to allow passing a Function through the user data
 
 function idasolfun(t::Float64, y::N_Vector, yp::N_Vector, r::N_Vector, userfun::Function)
     y = Sundials.asarray(y)
     yp = Sundials.asarray(yp)
     r = Sundials.asarray(r)
     userfun(t, y, yp, r)
-    return int32(0)   # indicates normal return
+    return Int32(0)   # indicates normal return
 end
 
 function idasol(f::Function, y0::Vector{Float64}, yp0::Vector{Float64}, t::Vector{Float64}; reltol::Float64=1e-4, abstol::Float64=1e-6)
@@ -308,7 +321,7 @@ function idasol(f::Function, y0::Vector{Float64}, yp0::Vector{Float64}, t::Vecto
     #         with time steps in `t` along rows and state variable `y` or `yp` along columns
     neq = length(y0)
     mem = IDACreate()
-    flag = IDAInit(mem, cfunction(idasolfun, Int32, (realtype, N_Vector, N_Vector, N_Vector, Function)), t[1], nvector(y0), nvector(yp0))
+    flag = IDAInit(mem, cfunction(idasolfun, Int32, (realtype, N_Vector, N_Vector, N_Vector, Ref{Function})), t[1], nvector(y0), nvector(yp0))
     flag = IDASetUserData(mem, f)
     flag = IDASStolerances(mem, reltol, abstol)
     flag = IDADense(mem, neq)
@@ -329,6 +342,7 @@ function idasol(f::Function, y0::Vector{Float64}, yp0::Vector{Float64}, t::Vecto
         yres[k,:] = y
         ypres[k,:] = yp
     end
+    IDAFree([mem])
     return yres, ypres
 end
 

--- a/src/cvode.jl
+++ b/src/cvode.jl
@@ -1,329 +1,630 @@
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvode/cvode.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
 
-recurs_sym_type(ex::Any) = 
-  (ex==None || typeof(ex)==Symbol || length(ex.args)==1) ? eval(ex) : Expr(ex.head, ex.args[1], recurs_sym_type(ex.args[2]))
-macro c(ret_type, func, arg_types, lib)
-  local _arg_types = Expr(:tuple, [recurs_sym_type(a) for a in arg_types.args]...)
-  local _ret_type = recurs_sym_type(ret_type)
-  local _args_in = Any[ symbol(string('a',x)) for x in 1:length(_arg_types.args) ]
-  local _lib = eval(lib)
-  quote
-    $(esc(func))($(_args_in...)) = ccall( ($(string(func)), $(Expr(:quote, _lib)) ), $_ret_type, $_arg_types, $(_args_in...) )
-  end
+
+function CVodeCreate(lmm::Int,iter::Int)
+    ccall((:CVodeCreate,libsundials_cvode),Ptr{Void},(Cint,Cint),lmm,iter)
 end
 
-macro ctypedef(fake_t,real_t)
-  real_t = recurs_sym_type(real_t)
-  quote
-    typealias $fake_t $real_t
-  end
+function CVodeSetErrHandlerFn(cvode_mem::Ptr{Void},ehfun::CVErrHandlerFn,eh_data::Ptr{Void})
+    ccall((:CVodeSetErrHandlerFn,libsundials_cvode),Cint,(Ptr{Void},CVErrHandlerFn,Ptr{Void}),cvode_mem,ehfun,eh_data)
 end
 
-# header: /usr/local/include/cvode/cvode_band.h
-@ctypedef CVDlsDenseJacFn Ptr{:Void}
-@ctypedef CVDlsBandJacFn Ptr{:Void}
-@c Int32 CVDlsSetDenseJacFn (Ptr{:None},:CVDlsDenseJacFn) shlib
-@c Int32 CVDlsSetBandJacFn (Ptr{:None},:CVDlsBandJacFn) shlib
-@c Int32 CVDlsGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 CVDlsGetNumJacEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVDlsGetNumRhsEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVDlsGetLastFlag (Ptr{:None},Ptr{:Clong}) shlib
-@c Ptr{:Uint8} CVDlsGetReturnFlagName (:Clong,) shlib
-@c Int32 CVBand (Ptr{:None},:Clong,:Clong,:Clong) shlib
+function CVodeSetErrFile(cvode_mem::Ptr{Void},errfp::Ptr{Void})
+    ccall((:CVodeSetErrFile,libsundials_cvode),Cint,(Ptr{Void},Ptr{Void}),cvode_mem,errfp)
+end
 
-# header: /usr/local/include/cvode/cvode_bandpre.h
-@c Int32 CVBandPrecInit (Ptr{:None},:Clong,:Clong,:Clong) shlib
-@c Int32 CVBandPrecGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 CVBandPrecGetNumRhsEvals (Ptr{:None},Ptr{:Clong}) shlib
+function CVodeSetUserData(cvode_mem::Ptr{Void},user_data::Ptr{Void})
+    ccall((:CVodeSetUserData,libsundials_cvode),Cint,(Ptr{Void},Ptr{Void}),cvode_mem,user_data)
+end
 
-# header: /usr/local/include/cvode/cvode_bbdpre.h
-@ctypedef CVLocalFn Ptr{:Void}
-@ctypedef CVCommFn Ptr{:Void}
-@c Int32 CVBBDPrecInit (Ptr{:None},:Clong,:Clong,:Clong,:Clong,:Clong,:realtype,:CVLocalFn,:CVCommFn) shlib
-@c Int32 CVBBDPrecReInit (Ptr{:None},:Clong,:Clong,:realtype) shlib
-@c Int32 CVBBDPrecGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 CVBBDPrecGetNumGfnEvals (Ptr{:None},Ptr{:Clong}) shlib
+function CVodeSetMaxOrd(cvode_mem::Ptr{Void},maxord::Int)
+    ccall((:CVodeSetMaxOrd,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,maxord)
+end
 
-# header: /usr/local/include/cvode/cvode_dense.h
-@c Int32 CVDense (Ptr{:None},:Clong) shlib
+function CVodeSetMaxNumSteps(cvode_mem::Ptr{Void},mxsteps::Int)
+    ccall((:CVodeSetMaxNumSteps,libsundials_cvode),Cint,(Ptr{Void},Clong),cvode_mem,mxsteps)
+end
 
-# header: /usr/local/include/cvode/cvode_diag.h
-@c Int32 CVDiag (Ptr{:None},) shlib
-@c Int32 CVDiagGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 CVDiagGetNumRhsEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVDiagGetLastFlag (Ptr{:None},Ptr{:Clong}) shlib
-@c Ptr{:Uint8} CVDiagGetReturnFlagName (:Clong,) shlib
+function CVodeSetMaxHnilWarns(cvode_mem::Ptr{Void},mxhnil::Int)
+    ccall((:CVodeSetMaxHnilWarns,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,mxhnil)
+end
 
-# header: /usr/local/include/cvode/cvode_direct.h
+function CVodeSetStabLimDet(cvode_mem::Ptr{Void},stldet::Int)
+    ccall((:CVodeSetStabLimDet,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,stldet)
+end
 
-# header: /usr/local/include/cvode/cvode.h
-@ctypedef ptrdiff_t Void
-@ctypedef size_t Void
-@ctypedef wchar_t Int32
-@ctypedef __u_char Uint8
-@ctypedef __u_short Uint16
-@ctypedef __u_int Uint32
-@ctypedef __u_long Culong
-@ctypedef __int8_t Uint8
-@ctypedef __uint8_t Uint8
-@ctypedef __int16_t Int16
-@ctypedef __uint16_t Uint16
-@ctypedef __int32_t Int32
-@ctypedef __uint32_t Uint32
-@ctypedef __int64_t Int64
-@ctypedef __uint64_t Uint64
-@ctypedef __quad_t Int64
-@ctypedef __u_quad_t Uint64
-@ctypedef __dev_t Uint64
-@ctypedef __uid_t Uint32
-@ctypedef __gid_t Uint32
-@ctypedef __ino_t Uint64
-@ctypedef __ino64_t Uint64
-@ctypedef __mode_t Uint32
-@ctypedef __nlink_t Uint64
-@ctypedef __off_t Int64
-@ctypedef __off64_t Int64
-@ctypedef __pid_t Int32
-@ctypedef __fsid_t Void
-@ctypedef __clock_t Int64
-@ctypedef __rlim_t Uint64
-@ctypedef __rlim64_t Uint64
-@ctypedef __id_t Uint32
-@ctypedef __time_t Int64
-@ctypedef __useconds_t Uint32
-@ctypedef __suseconds_t Int64
-@ctypedef __daddr_t Int32
-@ctypedef __swblk_t Int64
-@ctypedef __key_t Int32
-@ctypedef __clockid_t Int32
-@ctypedef __timer_t Ptr{:None}
-@ctypedef __blksize_t Int64
-@ctypedef __blkcnt_t Int64
-@ctypedef __blkcnt64_t Int64
-@ctypedef __fsblkcnt_t Uint64
-@ctypedef __fsblkcnt64_t Uint64
-@ctypedef __fsfilcnt_t Uint64
-@ctypedef __fsfilcnt64_t Uint64
-@ctypedef __ssize_t Int64
-@ctypedef __loff_t __off64_t
-@ctypedef __qaddr_t Ptr{:__quad_t}
-@ctypedef __caddr_t Ptr{:Uint8}
-@ctypedef __intptr_t Int64
-@ctypedef __socklen_t Uint32
-@ctypedef FILE Void
-@ctypedef __FILE Void
-@ctypedef __mbstate_t Void
-@ctypedef _G_fpos_t Void
-@ctypedef _G_fpos64_t Void
-@ctypedef _G_int16_t Int16
-@ctypedef _G_int32_t Int32
-@ctypedef _G_uint16_t Uint16
-@ctypedef _G_uint32_t Uint32
-@ctypedef va_list __builtin_va_list
-@ctypedef __gnuc_va_list __builtin_va_list
-@ctypedef _IO_lock_t None
-# enum __codecvt_result
-@ctypedef __codecvt_result Uint32
-const __codecvt_ok = 0
-const __codecvt_partial = 1
-const __codecvt_error = 2
-const __codecvt_noconv = 3
-# end
-@ctypedef _IO_FILE Void
-@ctypedef __io_read_fn Void
-@ctypedef __io_write_fn Void
-@ctypedef __io_seek_fn Void
-@ctypedef __io_close_fn Void
-@c Int32 __underflow (Ptr{:_IO_FILE},) shlib
-@c Int32 __uflow (Ptr{:_IO_FILE},) shlib
-@c Int32 __overflow (Ptr{:_IO_FILE},:Int32) shlib
-@c Int32 _IO_getc (Ptr{:_IO_FILE},) shlib
-@c Int32 _IO_putc (:Int32,Ptr{:_IO_FILE}) shlib
-@c Int32 _IO_feof (Ptr{:_IO_FILE},) shlib
-@c Int32 _IO_ferror (Ptr{:_IO_FILE},) shlib
-@c Int32 _IO_peekc_locked (Ptr{:_IO_FILE},) shlib
-@c None _IO_flockfile (Ptr{:_IO_FILE},) shlib
-@c None _IO_funlockfile (Ptr{:_IO_FILE},) shlib
-@c Int32 _IO_ftrylockfile (Ptr{:_IO_FILE},) shlib
-@c Int32 _IO_vfscanf (Ptr{:_IO_FILE},Ptr{:Uint8},Ptr{:__va_list_tag},Ptr{:Int32}) shlib
-@c Int32 _IO_vfprintf (Ptr{:_IO_FILE},Ptr{:Uint8},Ptr{:__va_list_tag}) shlib
-@c __ssize_t _IO_padn (Ptr{:_IO_FILE},:Int32,:__ssize_t) shlib
-@c size_t _IO_sgetn (Ptr{:_IO_FILE},Ptr{:None},:size_t) shlib
-@c __off64_t _IO_seekoff (Ptr{:_IO_FILE},:__off64_t,:Int32,:Int32) shlib
-@c __off64_t _IO_seekpos (Ptr{:_IO_FILE},:__off64_t,:Int32) shlib
-@c None _IO_free_backup_area (Ptr{:_IO_FILE},) shlib
-@ctypedef off_t __off_t
-@ctypedef ssize_t __ssize_t
-@ctypedef fpos_t _G_fpos_t
-@c Int32 remove (Ptr{:Uint8},) shlib
-@c Int32 rename (Ptr{:Uint8},Ptr{:Uint8}) shlib
-@c Int32 renameat (:Int32,Ptr{:Uint8},:Int32,Ptr{:Uint8}) shlib
-@c Ptr{:FILE} tmpfile () shlib
-@c Ptr{:Uint8} tmpnam (Ptr{:Uint8},) shlib
-@c Ptr{:Uint8} tmpnam_r (Ptr{:Uint8},) shlib
-@c Ptr{:Uint8} tempnam (Ptr{:Uint8},Ptr{:Uint8}) shlib
-@c Int32 fclose (Ptr{:FILE},) shlib
-@c Int32 fflush (Ptr{:FILE},) shlib
-@c Int32 fflush_unlocked (Ptr{:FILE},) shlib
-@c Ptr{:FILE} fopen (Ptr{:Uint8},Ptr{:Uint8}) shlib
-@c Ptr{:FILE} freopen (Ptr{:Uint8},Ptr{:Uint8},Ptr{:FILE}) shlib
-@c Ptr{:FILE} fdopen (:Int32,Ptr{:Uint8}) shlib
-@c Ptr{:FILE} fmemopen (Ptr{:None},:size_t,Ptr{:Uint8}) shlib
-@c Ptr{:FILE} open_memstream (Ptr{Ptr{:Uint8}},Ptr{:size_t}) shlib
-@c None setbuf (Ptr{:FILE},Ptr{:Uint8}) shlib
-@c Int32 setvbuf (Ptr{:FILE},Ptr{:Uint8},:Int32,:size_t) shlib
-@c None setbuffer (Ptr{:FILE},Ptr{:Uint8},:size_t) shlib
-@c None setlinebuf (Ptr{:FILE},) shlib
-@c Int32 fprintf (Ptr{:FILE},Ptr{:Uint8}) shlib
-@c Int32 printf (Ptr{:Uint8},) shlib
-@c Int32 sprintf (Ptr{:Uint8},Ptr{:Uint8}) shlib
-@c Int32 vfprintf (Ptr{:FILE},Ptr{:Uint8},Ptr{:__va_list_tag}) shlib
-@c Int32 vprintf (Ptr{:Uint8},Ptr{:__va_list_tag}) shlib
-@c Int32 vsprintf (Ptr{:Uint8},Ptr{:Uint8},Ptr{:__va_list_tag}) shlib
-@c Int32 snprintf (Ptr{:Uint8},:size_t,Ptr{:Uint8}) shlib
-@c Int32 vsnprintf (Ptr{:Uint8},:size_t,Ptr{:Uint8},Ptr{:__va_list_tag}) shlib
-@c Int32 vdprintf (:Int32,Ptr{:Uint8},Ptr{:__va_list_tag}) shlib
-@c Int32 dprintf (:Int32,Ptr{:Uint8}) shlib
-@c Int32 fscanf (Ptr{:FILE},Ptr{:Uint8}) shlib
-@c Int32 scanf (Ptr{:Uint8},) shlib
-@c Int32 sscanf (Ptr{:Uint8},Ptr{:Uint8}) shlib
-@c Int32 vfscanf (Ptr{:FILE},Ptr{:Uint8},Ptr{:__va_list_tag}) shlib
-@c Int32 vscanf (Ptr{:Uint8},Ptr{:__va_list_tag}) shlib
-@c Int32 vsscanf (Ptr{:Uint8},Ptr{:Uint8},Ptr{:__va_list_tag}) shlib
-@c Int32 fgetc (Ptr{:FILE},) shlib
-@c Int32 getc (Ptr{:FILE},) shlib
-@c Int32 getchar () shlib
-@c Int32 getc_unlocked (Ptr{:FILE},) shlib
-@c Int32 getchar_unlocked () shlib
-@c Int32 fgetc_unlocked (Ptr{:FILE},) shlib
-@c Int32 fputc (:Int32,Ptr{:FILE}) shlib
-@c Int32 putc (:Int32,Ptr{:FILE}) shlib
-@c Int32 putchar (:Int32,) shlib
-@c Int32 fputc_unlocked (:Int32,Ptr{:FILE}) shlib
-@c Int32 putc_unlocked (:Int32,Ptr{:FILE}) shlib
-@c Int32 putchar_unlocked (:Int32,) shlib
-@c Int32 getw (Ptr{:FILE},) shlib
-@c Int32 putw (:Int32,Ptr{:FILE}) shlib
-@c Ptr{:Uint8} fgets (Ptr{:Uint8},:Int32,Ptr{:FILE}) shlib
-@c Ptr{:Uint8} gets (Ptr{:Uint8},) shlib
-@c __ssize_t __getdelim (Ptr{Ptr{:Uint8}},Ptr{:size_t},:Int32,Ptr{:FILE}) shlib
-@c __ssize_t getdelim (Ptr{Ptr{:Uint8}},Ptr{:size_t},:Int32,Ptr{:FILE}) shlib
-@c __ssize_t getline (Ptr{Ptr{:Uint8}},Ptr{:size_t},Ptr{:FILE}) shlib
-@c Int32 fputs (Ptr{:Uint8},Ptr{:FILE}) shlib
-@c Int32 puts (Ptr{:Uint8},) shlib
-@c Int32 ungetc (:Int32,Ptr{:FILE}) shlib
-@c size_t fread (Ptr{:None},:size_t,:size_t,Ptr{:FILE}) shlib
-@c size_t fwrite (Ptr{:None},:size_t,:size_t,Ptr{:FILE}) shlib
-@c size_t fread_unlocked (Ptr{:None},:size_t,:size_t,Ptr{:FILE}) shlib
-@c size_t fwrite_unlocked (Ptr{:None},:size_t,:size_t,Ptr{:FILE}) shlib
-@c Int32 fseek (Ptr{:FILE},:Clong,:Int32) shlib
-@c Clong ftell (Ptr{:FILE},) shlib
-@c None rewind (Ptr{:FILE},) shlib
-@c Int32 fseeko (Ptr{:FILE},:__off_t,:Int32) shlib
-@c __off_t ftello (Ptr{:FILE},) shlib
-@c Int32 fgetpos (Ptr{:FILE},Ptr{:fpos_t}) shlib
-@c Int32 fsetpos (Ptr{:FILE},Ptr{:fpos_t}) shlib
-@c None clearerr (Ptr{:FILE},) shlib
-@c Int32 feof (Ptr{:FILE},) shlib
-@c Int32 ferror (Ptr{:FILE},) shlib
-@c None clearerr_unlocked (Ptr{:FILE},) shlib
-@c Int32 feof_unlocked (Ptr{:FILE},) shlib
-@c Int32 ferror_unlocked (Ptr{:FILE},) shlib
-@c None perror (Ptr{:Uint8},) shlib
-@c Int32 fileno (Ptr{:FILE},) shlib
-@c Int32 fileno_unlocked (Ptr{:FILE},) shlib
-@c Ptr{:FILE} popen (Ptr{:Uint8},Ptr{:Uint8}) shlib
-@c Int32 pclose (Ptr{:FILE},) shlib
-@c Ptr{:Uint8} ctermid (Ptr{:Uint8},) shlib
-@c None flockfile (Ptr{:FILE},) shlib
-@c Int32 ftrylockfile (Ptr{:FILE},) shlib
-@c None funlockfile (Ptr{:FILE},) shlib
-@ctypedef CVRhsFn Ptr{:Void}
-@ctypedef CVRootFn Ptr{:Void}
-@ctypedef CVEwtFn Ptr{:Void}
-@ctypedef CVErrHandlerFn Ptr{:Void}
-@c Ptr{:None} CVodeCreate (:Int32,:Int32) shlib
-@c Int32 CVodeSetErrHandlerFn (Ptr{:None},:CVErrHandlerFn,Ptr{:None}) shlib
-@c Int32 CVodeSetErrFile (Ptr{:None},Ptr{:FILE}) shlib
-@c Int32 CVodeSetUserData (Ptr{:None},Ptr{:None}) shlib
-@c Int32 CVodeSetMaxOrd (Ptr{:None},:Int32) shlib
-@c Int32 CVodeSetMaxNumSteps (Ptr{:None},:Clong) shlib
-@c Int32 CVodeSetMaxHnilWarns (Ptr{:None},:Int32) shlib
-@c Int32 CVodeSetStabLimDet (Ptr{:None},:Int32) shlib
-@c Int32 CVodeSetInitStep (Ptr{:None},:realtype) shlib
-@c Int32 CVodeSetMinStep (Ptr{:None},:realtype) shlib
-@c Int32 CVodeSetMaxStep (Ptr{:None},:realtype) shlib
-@c Int32 CVodeSetStopTime (Ptr{:None},:realtype) shlib
-@c Int32 CVodeSetMaxErrTestFails (Ptr{:None},:Int32) shlib
-@c Int32 CVodeSetMaxNonlinIters (Ptr{:None},:Int32) shlib
-@c Int32 CVodeSetMaxConvFails (Ptr{:None},:Int32) shlib
-@c Int32 CVodeSetNonlinConvCoef (Ptr{:None},:realtype) shlib
-@c Int32 CVodeSetIterType (Ptr{:None},:Int32) shlib
-@c Int32 CVodeSetRootDirection (Ptr{:None},Ptr{:Int32}) shlib
-@c Int32 CVodeSetNoInactiveRootWarn (Ptr{:None},) shlib
-@c Int32 CVodeInit (Ptr{:None},:CVRhsFn,:realtype,:N_Vector) shlib
-@c Int32 CVodeReInit (Ptr{:None},:realtype,:N_Vector) shlib
-@c Int32 CVodeSStolerances (Ptr{:None},:realtype,:realtype) shlib
-@c Int32 CVodeSVtolerances (Ptr{:None},:realtype,:N_Vector) shlib
-@c Int32 CVodeWFtolerances (Ptr{:None},:CVEwtFn) shlib
-@c Int32 CVodeRootInit (Ptr{:None},:Int32,:CVRootFn) shlib
-@c Int32 CVode (Ptr{:None},:realtype,:N_Vector,Ptr{:realtype},:Int32) shlib
-@c Int32 CVodeGetDky (Ptr{:None},:realtype,:Int32,:N_Vector) shlib
-@c Int32 CVodeGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 CVodeGetNumSteps (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVodeGetNumRhsEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVodeGetNumLinSolvSetups (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVodeGetNumErrTestFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVodeGetLastOrder (Ptr{:None},Ptr{:Int32}) shlib
-@c Int32 CVodeGetCurrentOrder (Ptr{:None},Ptr{:Int32}) shlib
-@c Int32 CVodeGetNumStabLimOrderReds (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVodeGetActualInitStep (Ptr{:None},Ptr{:realtype}) shlib
-@c Int32 CVodeGetLastStep (Ptr{:None},Ptr{:realtype}) shlib
-@c Int32 CVodeGetCurrentStep (Ptr{:None},Ptr{:realtype}) shlib
-@c Int32 CVodeGetCurrentTime (Ptr{:None},Ptr{:realtype}) shlib
-@c Int32 CVodeGetTolScaleFactor (Ptr{:None},Ptr{:realtype}) shlib
-@c Int32 CVodeGetErrWeights (Ptr{:None},:N_Vector) shlib
-@c Int32 CVodeGetEstLocalErrors (Ptr{:None},:N_Vector) shlib
-@c Int32 CVodeGetNumGEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVodeGetRootInfo (Ptr{:None},Ptr{:Int32}) shlib
-@c Int32 CVodeGetIntegratorStats (Ptr{:None},Ptr{:Clong},Ptr{:Clong},Ptr{:Clong},Ptr{:Clong},Ptr{:Int32},Ptr{:Int32},Ptr{:realtype},Ptr{:realtype},Ptr{:realtype},Ptr{:realtype}) shlib
-@c Int32 CVodeGetNumNonlinSolvIters (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVodeGetNumNonlinSolvConvFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVodeGetNonlinSolvStats (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Ptr{:Uint8} CVodeGetReturnFlagName (:Clong,) shlib
-@c None CVodeFree (Ptr{Ptr{:None}},) shlib
+function CVodeSetInitStep(cvode_mem::Ptr{Void},hin::realtype)
+    ccall((:CVodeSetInitStep,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,hin)
+end
 
-# header: /usr/local/include/cvode/cvode_impl.h
-@ctypedef CVodeMem Ptr{:Void}
-@c Int32 CVEwtSet (:N_Vector,:N_Vector,Ptr{:None}) shlib
-@c None CVProcessError (:CVodeMem,:Int32,Ptr{:Uint8},Ptr{:Uint8},Ptr{:Uint8}) shlib
-@c None CVErrHandler (:Int32,Ptr{:Uint8},Ptr{:Uint8},Ptr{:Uint8},Ptr{:None}) shlib
+function CVodeSetMinStep(cvode_mem::Ptr{Void},hmin::realtype)
+    ccall((:CVodeSetMinStep,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,hmin)
+end
 
-# header: /usr/local/include/cvode/cvode_spbcgs.h
-@ctypedef CVSpilsPrecSetupFn Ptr{:Void}
-@ctypedef CVSpilsPrecSolveFn Ptr{:Void}
-@ctypedef CVSpilsJacTimesVecFn Ptr{:Void}
-@c Int32 CVSpilsSetPrecType (Ptr{:None},:Int32) shlib
-@c Int32 CVSpilsSetGSType (Ptr{:None},:Int32) shlib
-@c Int32 CVSpilsSetMaxl (Ptr{:None},:Int32) shlib
-@c Int32 CVSpilsSetEpsLin (Ptr{:None},:realtype) shlib
-@c Int32 CVSpilsSetPreconditioner (Ptr{:None},:CVSpilsPrecSetupFn,:CVSpilsPrecSolveFn) shlib
-@c Int32 CVSpilsSetJacTimesVecFn (Ptr{:None},:CVSpilsJacTimesVecFn) shlib
-@c Int32 CVSpilsGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 CVSpilsGetNumPrecEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVSpilsGetNumPrecSolves (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVSpilsGetNumLinIters (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVSpilsGetNumConvFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVSpilsGetNumJtimesEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVSpilsGetNumRhsEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVSpilsGetLastFlag (Ptr{:None},Ptr{:Clong}) shlib
-@c Ptr{:Uint8} CVSpilsGetReturnFlagName (:Clong,) shlib
-@c Int32 CVSpbcg (Ptr{:None},:Int32,:Int32) shlib
+function CVodeSetMaxStep(cvode_mem::Ptr{Void},hmax::realtype)
+    ccall((:CVodeSetMaxStep,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,hmax)
+end
 
-# header: /usr/local/include/cvode/cvode_spgmr.h
-@c Int32 CVSpgmr (Ptr{:None},:Int32,:Int32) shlib
+function CVodeSetStopTime(cvode_mem::Ptr{Void},tstop::realtype)
+    ccall((:CVodeSetStopTime,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,tstop)
+end
 
-# header: /usr/local/include/cvode/cvode_spils.h
+function CVodeSetMaxErrTestFails(cvode_mem::Ptr{Void},maxnef::Int)
+    ccall((:CVodeSetMaxErrTestFails,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,maxnef)
+end
 
-# header: /usr/local/include/cvode/cvode_sptfqmr.h
-@c Int32 CVSptfqmr (Ptr{:None},:Int32,:Int32) shlib
+function CVodeSetMaxNonlinIters(cvode_mem::Ptr{Void},maxcor::Int)
+    ccall((:CVodeSetMaxNonlinIters,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,maxcor)
+end
 
+function CVodeSetMaxConvFails(cvode_mem::Ptr{Void},maxncf::Int)
+    ccall((:CVodeSetMaxConvFails,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,maxncf)
+end
+
+function CVodeSetNonlinConvCoef(cvode_mem::Ptr{Void},nlscoef::realtype)
+    ccall((:CVodeSetNonlinConvCoef,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,nlscoef)
+end
+
+function CVodeSetIterType(cvode_mem::Ptr{Void},iter::Int)
+    ccall((:CVodeSetIterType,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,iter)
+end
+
+function CVodeSetRootDirection(cvode_mem::Ptr{Void},rootdir::Ptr{Cint})
+    ccall((:CVodeSetRootDirection,libsundials_cvode),Cint,(Ptr{Void},Ptr{Cint}),cvode_mem,rootdir)
+end
+
+function CVodeSetNoInactiveRootWarn(cvode_mem::Ptr{Void})
+    ccall((:CVodeSetNoInactiveRootWarn,libsundials_cvode),Cint,(Ptr{Void},),cvode_mem)
+end
+
+function CVodeInit(cvode_mem::Ptr{Void},f::CVRhsFn,t0::realtype,y0::N_Vector)
+    ccall((:CVodeInit,libsundials_cvode),Cint,(Ptr{Void},CVRhsFn,realtype,N_Vector),cvode_mem,f,t0,y0)
+end
+
+function CVodeReInit(cvode_mem::Ptr{Void},t0::realtype,y0::N_Vector)
+    ccall((:CVodeReInit,libsundials_cvode),Cint,(Ptr{Void},realtype,N_Vector),cvode_mem,t0,y0)
+end
+
+function CVodeSStolerances(cvode_mem::Ptr{Void},reltol::realtype,abstol::realtype)
+    ccall((:CVodeSStolerances,libsundials_cvode),Cint,(Ptr{Void},realtype,realtype),cvode_mem,reltol,abstol)
+end
+
+function CVodeSVtolerances(cvode_mem::Ptr{Void},reltol::realtype,abstol::N_Vector)
+    ccall((:CVodeSVtolerances,libsundials_cvode),Cint,(Ptr{Void},realtype,N_Vector),cvode_mem,reltol,abstol)
+end
+
+function CVodeWFtolerances(cvode_mem::Ptr{Void},efun::CVEwtFn)
+    ccall((:CVodeWFtolerances,libsundials_cvode),Cint,(Ptr{Void},CVEwtFn),cvode_mem,efun)
+end
+
+function CVodeRootInit(cvode_mem::Ptr{Void},nrtfn::Int,g::CVRootFn)
+    ccall((:CVodeRootInit,libsundials_cvode),Cint,(Ptr{Void},Cint,CVRootFn),cvode_mem,nrtfn,g)
+end
+
+function CVode(cvode_mem::Ptr{Void},tout::realtype,yout::N_Vector,tret::Vector{realtype},itask::Int)
+    ccall((:CVode,libsundials_cvode),Cint,(Ptr{Void},realtype,N_Vector,Ptr{realtype},Cint),cvode_mem,tout,yout,tret,itask)
+end
+
+function CVodeGetDky(cvode_mem::Ptr{Void},t::realtype,k::Int,dky::N_Vector)
+    ccall((:CVodeGetDky,libsundials_cvode),Cint,(Ptr{Void},realtype,Cint,N_Vector),cvode_mem,t,k,dky)
+end
+
+function CVodeGetWorkSpace(cvode_mem::Ptr{Void},lenrw::Ptr{Clong},leniw::Ptr{Clong})
+    ccall((:CVodeGetWorkSpace,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,lenrw,leniw)
+end
+
+function CVodeGetNumSteps(cvode_mem::Ptr{Void},nsteps::Ptr{Clong})
+    ccall((:CVodeGetNumSteps,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nsteps)
+end
+
+function CVodeGetNumRhsEvals(cvode_mem::Ptr{Void},nfevals::Ptr{Clong})
+    ccall((:CVodeGetNumRhsEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nfevals)
+end
+
+function CVodeGetNumLinSolvSetups(cvode_mem::Ptr{Void},nlinsetups::Ptr{Clong})
+    ccall((:CVodeGetNumLinSolvSetups,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nlinsetups)
+end
+
+function CVodeGetNumErrTestFails(cvode_mem::Ptr{Void},netfails::Ptr{Clong})
+    ccall((:CVodeGetNumErrTestFails,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,netfails)
+end
+
+function CVodeGetLastOrder(cvode_mem::Ptr{Void},qlast::Ptr{Cint})
+    ccall((:CVodeGetLastOrder,libsundials_cvode),Cint,(Ptr{Void},Ptr{Cint}),cvode_mem,qlast)
+end
+
+function CVodeGetCurrentOrder(cvode_mem::Ptr{Void},qcur::Ptr{Cint})
+    ccall((:CVodeGetCurrentOrder,libsundials_cvode),Cint,(Ptr{Void},Ptr{Cint}),cvode_mem,qcur)
+end
+
+function CVodeGetNumStabLimOrderReds(cvode_mem::Ptr{Void},nslred::Ptr{Clong})
+    ccall((:CVodeGetNumStabLimOrderReds,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nslred)
+end
+
+function CVodeGetActualInitStep(cvode_mem::Ptr{Void},hinused::Vector{realtype})
+    ccall((:CVodeGetActualInitStep,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype}),cvode_mem,hinused)
+end
+
+function CVodeGetLastStep(cvode_mem::Ptr{Void},hlast::Vector{realtype})
+    ccall((:CVodeGetLastStep,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype}),cvode_mem,hlast)
+end
+
+function CVodeGetCurrentStep(cvode_mem::Ptr{Void},hcur::Vector{realtype})
+    ccall((:CVodeGetCurrentStep,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype}),cvode_mem,hcur)
+end
+
+function CVodeGetCurrentTime(cvode_mem::Ptr{Void},tcur::Vector{realtype})
+    ccall((:CVodeGetCurrentTime,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype}),cvode_mem,tcur)
+end
+
+function CVodeGetTolScaleFactor(cvode_mem::Ptr{Void},tolsfac::Vector{realtype})
+    ccall((:CVodeGetTolScaleFactor,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype}),cvode_mem,tolsfac)
+end
+
+function CVodeGetErrWeights(cvode_mem::Ptr{Void},eweight::N_Vector)
+    ccall((:CVodeGetErrWeights,libsundials_cvode),Cint,(Ptr{Void},N_Vector),cvode_mem,eweight)
+end
+
+function CVodeGetEstLocalErrors(cvode_mem::Ptr{Void},ele::N_Vector)
+    ccall((:CVodeGetEstLocalErrors,libsundials_cvode),Cint,(Ptr{Void},N_Vector),cvode_mem,ele)
+end
+
+function CVodeGetNumGEvals(cvode_mem::Ptr{Void},ngevals::Ptr{Clong})
+    ccall((:CVodeGetNumGEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,ngevals)
+end
+
+function CVodeGetRootInfo(cvode_mem::Ptr{Void},rootsfound::Ptr{Cint})
+    ccall((:CVodeGetRootInfo,libsundials_cvode),Cint,(Ptr{Void},Ptr{Cint}),cvode_mem,rootsfound)
+end
+
+function CVodeGetIntegratorStats(cvode_mem::Ptr{Void},nsteps::Ptr{Clong},nfevals::Ptr{Clong},nlinsetups::Ptr{Clong},netfails::Ptr{Clong},qlast::Ptr{Cint},qcur::Ptr{Cint},hinused::Vector{realtype},hlast::Vector{realtype},hcur::Vector{realtype},tcur::Vector{realtype})
+    ccall((:CVodeGetIntegratorStats,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Cint},Ptr{Cint},Ptr{realtype},Ptr{realtype},Ptr{realtype},Ptr{realtype}),cvode_mem,nsteps,nfevals,nlinsetups,netfails,qlast,qcur,hinused,hlast,hcur,tcur)
+end
+
+function CVodeGetNumNonlinSolvIters(cvode_mem::Ptr{Void},nniters::Ptr{Clong})
+    ccall((:CVodeGetNumNonlinSolvIters,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nniters)
+end
+
+function CVodeGetNumNonlinSolvConvFails(cvode_mem::Ptr{Void},nncfails::Ptr{Clong})
+    ccall((:CVodeGetNumNonlinSolvConvFails,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nncfails)
+end
+
+function CVodeGetNonlinSolvStats(cvode_mem::Ptr{Void},nniters::Ptr{Clong},nncfails::Ptr{Clong})
+    ccall((:CVodeGetNonlinSolvStats,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,nniters,nncfails)
+end
+
+function CVodeGetReturnFlagName(flag::Int)
+    ccall((:CVodeGetReturnFlagName,libsundials_cvode),Ptr{UInt8},(Clong,),flag)
+end
+
+function CVodeFree(cvode_mem::Vector{Ptr{Void}})
+    ccall((:CVodeFree,libsundials_cvode),Void,(Ptr{Ptr{Void}},),cvode_mem)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvode/cvode_direct.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+
+function CVDlsSetDenseJacFn(cvode_mem::Ptr{Void},jac::CVDlsDenseJacFn)
+    ccall((:CVDlsSetDenseJacFn,libsundials_cvode),Cint,(Ptr{Void},CVDlsDenseJacFn),cvode_mem,jac)
+end
+
+function CVDlsSetBandJacFn(cvode_mem::Ptr{Void},jac::CVDlsBandJacFn)
+    ccall((:CVDlsSetBandJacFn,libsundials_cvode),Cint,(Ptr{Void},CVDlsBandJacFn),cvode_mem,jac)
+end
+
+function CVDlsGetWorkSpace(cvode_mem::Ptr{Void},lenrwLS::Ptr{Clong},leniwLS::Ptr{Clong})
+    ccall((:CVDlsGetWorkSpace,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,lenrwLS,leniwLS)
+end
+
+function CVDlsGetNumJacEvals(cvode_mem::Ptr{Void},njevals::Ptr{Clong})
+    ccall((:CVDlsGetNumJacEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,njevals)
+end
+
+function CVDlsGetNumRhsEvals(cvode_mem::Ptr{Void},nfevalsLS::Ptr{Clong})
+    ccall((:CVDlsGetNumRhsEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nfevalsLS)
+end
+
+function CVDlsGetLastFlag(cvode_mem::Ptr{Void},flag::Ptr{Clong})
+    ccall((:CVDlsGetLastFlag,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,flag)
+end
+
+function CVDlsGetReturnFlagName(flag::Int)
+    ccall((:CVDlsGetReturnFlagName,libsundials_cvode),Ptr{UInt8},(Clong,),flag)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvode/cvode_spils.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function CVSpilsSetPrecType(cvode_mem::Ptr{Void},pretype::Int)
+    ccall((:CVSpilsSetPrecType,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,pretype)
+end
+
+function CVSpilsSetGSType(cvode_mem::Ptr{Void},gstype::Int)
+    ccall((:CVSpilsSetGSType,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,gstype)
+end
+
+function CVSpilsSetMaxl(cvode_mem::Ptr{Void},maxl::Int)
+    ccall((:CVSpilsSetMaxl,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,maxl)
+end
+
+function CVSpilsSetEpsLin(cvode_mem::Ptr{Void},eplifac::realtype)
+    ccall((:CVSpilsSetEpsLin,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,eplifac)
+end
+
+function CVSpilsSetPreconditioner(cvode_mem::Ptr{Void},pset::CVSpilsPrecSetupFn,psolve::CVSpilsPrecSolveFn)
+    ccall((:CVSpilsSetPreconditioner,libsundials_cvode),Cint,(Ptr{Void},CVSpilsPrecSetupFn,CVSpilsPrecSolveFn),cvode_mem,pset,psolve)
+end
+
+function CVSpilsSetJacTimesVecFn(cvode_mem::Ptr{Void},jtv::CVSpilsJacTimesVecFn)
+    ccall((:CVSpilsSetJacTimesVecFn,libsundials_cvode),Cint,(Ptr{Void},CVSpilsJacTimesVecFn),cvode_mem,jtv)
+end
+
+function CVSpilsGetWorkSpace(cvode_mem::Ptr{Void},lenrwLS::Ptr{Clong},leniwLS::Ptr{Clong})
+    ccall((:CVSpilsGetWorkSpace,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,lenrwLS,leniwLS)
+end
+
+function CVSpilsGetNumPrecEvals(cvode_mem::Ptr{Void},npevals::Ptr{Clong})
+    ccall((:CVSpilsGetNumPrecEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,npevals)
+end
+
+function CVSpilsGetNumPrecSolves(cvode_mem::Ptr{Void},npsolves::Ptr{Clong})
+    ccall((:CVSpilsGetNumPrecSolves,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,npsolves)
+end
+
+function CVSpilsGetNumLinIters(cvode_mem::Ptr{Void},nliters::Ptr{Clong})
+    ccall((:CVSpilsGetNumLinIters,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nliters)
+end
+
+function CVSpilsGetNumConvFails(cvode_mem::Ptr{Void},nlcfails::Ptr{Clong})
+    ccall((:CVSpilsGetNumConvFails,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nlcfails)
+end
+
+function CVSpilsGetNumJtimesEvals(cvode_mem::Ptr{Void},njvevals::Ptr{Clong})
+    ccall((:CVSpilsGetNumJtimesEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,njvevals)
+end
+
+function CVSpilsGetNumRhsEvals(cvode_mem::Ptr{Void},nfevalsLS::Ptr{Clong})
+    ccall((:CVSpilsGetNumRhsEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nfevalsLS)
+end
+
+function CVSpilsGetLastFlag(cvode_mem::Ptr{Void},flag::Ptr{Clong})
+    ccall((:CVSpilsGetLastFlag,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,flag)
+end
+
+function CVSpilsGetReturnFlagName(flag::Int)
+    ccall((:CVSpilsGetReturnFlagName,libsundials_cvode),Ptr{UInt8},(Clong,),flag)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvode/cvode_band.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function CVBand(cvode_mem::Ptr{Void},N::Int,mupper::Int,mlower::Int)
+    ccall((:CVBand,libsundials_cvode),Cint,(Ptr{Void},Clong,Clong,Clong),cvode_mem,N,mupper,mlower)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvode/cvode_bandpre.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function CVBandPrecInit(cvode_mem::Ptr{Void},N::Int,mu::Int,ml::Int)
+    ccall((:CVBandPrecInit,libsundials_cvode),Cint,(Ptr{Void},Clong,Clong,Clong),cvode_mem,N,mu,ml)
+end
+
+function CVBandPrecGetWorkSpace(cvode_mem::Ptr{Void},lenrwLS::Ptr{Clong},leniwLS::Ptr{Clong})
+    ccall((:CVBandPrecGetWorkSpace,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,lenrwLS,leniwLS)
+end
+
+function CVBandPrecGetNumRhsEvals(cvode_mem::Ptr{Void},nfevalsBP::Ptr{Clong})
+    ccall((:CVBandPrecGetNumRhsEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nfevalsBP)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvode/cvode_bbdpre.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+
+
+function CVBBDPrecInit(cvode_mem::Ptr{Void},Nlocal::Int,mudq::Int,mldq::Int,mukeep::Int,mlkeep::Int,dqrely::realtype,gloc::CVLocalFn,cfn::CVCommFn)
+    ccall((:CVBBDPrecInit,libsundials_cvode),Cint,(Ptr{Void},Clong,Clong,Clong,Clong,Clong,realtype,CVLocalFn,CVCommFn),cvode_mem,Nlocal,mudq,mldq,mukeep,mlkeep,dqrely,gloc,cfn)
+end
+
+function CVBBDPrecReInit(cvode_mem::Ptr{Void},mudq::Int,mldq::Int,dqrely::realtype)
+    ccall((:CVBBDPrecReInit,libsundials_cvode),Cint,(Ptr{Void},Clong,Clong,realtype),cvode_mem,mudq,mldq,dqrely)
+end
+
+function CVBBDPrecGetWorkSpace(cvode_mem::Ptr{Void},lenrwLS::Ptr{Clong},leniwLS::Ptr{Clong})
+    ccall((:CVBBDPrecGetWorkSpace,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,lenrwLS,leniwLS)
+end
+
+function CVBBDPrecGetNumGfnEvals(cvode_mem::Ptr{Void},ngevalsBBDP::Ptr{Clong})
+    ccall((:CVBBDPrecGetNumGfnEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,ngevalsBBDP)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvode/cvode_dense.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function CVDense(cvode_mem::Ptr{Void},N::Int)
+    ccall((:CVDense,libsundials_cvode),Cint,(Ptr{Void},Clong),cvode_mem,N)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvode/cvode_diag.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+
+function CVDiag(cvode_mem::Ptr{Void})
+    ccall((:CVDiag,libsundials_cvode),Cint,(Ptr{Void},),cvode_mem)
+end
+
+function CVDiagGetWorkSpace(cvode_mem::Ptr{Void},lenrwLS::Ptr{Clong},leniwLS::Ptr{Clong})
+    ccall((:CVDiagGetWorkSpace,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,lenrwLS,leniwLS)
+end
+
+function CVDiagGetNumRhsEvals(cvode_mem::Ptr{Void},nfevalsLS::Ptr{Clong})
+    ccall((:CVDiagGetNumRhsEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nfevalsLS)
+end
+
+function CVDiagGetLastFlag(cvode_mem::Ptr{Void},flag::Ptr{Clong})
+    ccall((:CVDiagGetLastFlag,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,flag)
+end
+
+function CVDiagGetReturnFlagName(flag::Int)
+    ccall((:CVDiagGetReturnFlagName,libsundials_cvode),Ptr{UInt8},(Clong,),flag)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvode/cvode_impl.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function CVodeCreate(lmm::Int,iter::Int)
+    ccall((:CVodeCreate,libsundials_cvode),Ptr{Void},(Cint,Cint),lmm,iter)
+end
+
+function CVodeSetErrHandlerFn(cvode_mem::Ptr{Void},ehfun::CVErrHandlerFn,eh_data::Ptr{Void})
+    ccall((:CVodeSetErrHandlerFn,libsundials_cvode),Cint,(Ptr{Void},CVErrHandlerFn,Ptr{Void}),cvode_mem,ehfun,eh_data)
+end
+
+function CVodeSetErrFile(cvode_mem::Ptr{Void},errfp::Ptr{Void})
+    ccall((:CVodeSetErrFile,libsundials_cvode),Cint,(Ptr{Void},Ptr{Void}),cvode_mem,errfp)
+end
+
+function CVodeSetUserData(cvode_mem::Ptr{Void},user_data::Ptr{Void})
+    ccall((:CVodeSetUserData,libsundials_cvode),Cint,(Ptr{Void},Ptr{Void}),cvode_mem,user_data)
+end
+
+function CVodeSetMaxOrd(cvode_mem::Ptr{Void},maxord::Int)
+    ccall((:CVodeSetMaxOrd,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,maxord)
+end
+
+function CVodeSetMaxNumSteps(cvode_mem::Ptr{Void},mxsteps::Int)
+    ccall((:CVodeSetMaxNumSteps,libsundials_cvode),Cint,(Ptr{Void},Clong),cvode_mem,mxsteps)
+end
+
+function CVodeSetMaxHnilWarns(cvode_mem::Ptr{Void},mxhnil::Int)
+    ccall((:CVodeSetMaxHnilWarns,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,mxhnil)
+end
+
+function CVodeSetStabLimDet(cvode_mem::Ptr{Void},stldet::Int)
+    ccall((:CVodeSetStabLimDet,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,stldet)
+end
+
+function CVodeSetInitStep(cvode_mem::Ptr{Void},hin::realtype)
+    ccall((:CVodeSetInitStep,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,hin)
+end
+
+function CVodeSetMinStep(cvode_mem::Ptr{Void},hmin::realtype)
+    ccall((:CVodeSetMinStep,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,hmin)
+end
+
+function CVodeSetMaxStep(cvode_mem::Ptr{Void},hmax::realtype)
+    ccall((:CVodeSetMaxStep,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,hmax)
+end
+
+function CVodeSetStopTime(cvode_mem::Ptr{Void},tstop::realtype)
+    ccall((:CVodeSetStopTime,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,tstop)
+end
+
+function CVodeSetMaxErrTestFails(cvode_mem::Ptr{Void},maxnef::Int)
+    ccall((:CVodeSetMaxErrTestFails,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,maxnef)
+end
+
+function CVodeSetMaxNonlinIters(cvode_mem::Ptr{Void},maxcor::Int)
+    ccall((:CVodeSetMaxNonlinIters,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,maxcor)
+end
+
+function CVodeSetMaxConvFails(cvode_mem::Ptr{Void},maxncf::Int)
+    ccall((:CVodeSetMaxConvFails,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,maxncf)
+end
+
+function CVodeSetNonlinConvCoef(cvode_mem::Ptr{Void},nlscoef::realtype)
+    ccall((:CVodeSetNonlinConvCoef,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,nlscoef)
+end
+
+function CVodeSetIterType(cvode_mem::Ptr{Void},iter::Int)
+    ccall((:CVodeSetIterType,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,iter)
+end
+
+function CVodeSetRootDirection(cvode_mem::Ptr{Void},rootdir::Ptr{Cint})
+    ccall((:CVodeSetRootDirection,libsundials_cvode),Cint,(Ptr{Void},Ptr{Cint}),cvode_mem,rootdir)
+end
+
+function CVodeSetNoInactiveRootWarn(cvode_mem::Ptr{Void})
+    ccall((:CVodeSetNoInactiveRootWarn,libsundials_cvode),Cint,(Ptr{Void},),cvode_mem)
+end
+
+function CVodeInit(cvode_mem::Ptr{Void},f::CVRhsFn,t0::realtype,y0::N_Vector)
+    ccall((:CVodeInit,libsundials_cvode),Cint,(Ptr{Void},CVRhsFn,realtype,N_Vector),cvode_mem,f,t0,y0)
+end
+
+function CVodeReInit(cvode_mem::Ptr{Void},t0::realtype,y0::N_Vector)
+    ccall((:CVodeReInit,libsundials_cvode),Cint,(Ptr{Void},realtype,N_Vector),cvode_mem,t0,y0)
+end
+
+function CVodeSStolerances(cvode_mem::Ptr{Void},reltol::realtype,abstol::realtype)
+    ccall((:CVodeSStolerances,libsundials_cvode),Cint,(Ptr{Void},realtype,realtype),cvode_mem,reltol,abstol)
+end
+
+function CVodeSVtolerances(cvode_mem::Ptr{Void},reltol::realtype,abstol::N_Vector)
+    ccall((:CVodeSVtolerances,libsundials_cvode),Cint,(Ptr{Void},realtype,N_Vector),cvode_mem,reltol,abstol)
+end
+
+function CVodeWFtolerances(cvode_mem::Ptr{Void},efun::CVEwtFn)
+    ccall((:CVodeWFtolerances,libsundials_cvode),Cint,(Ptr{Void},CVEwtFn),cvode_mem,efun)
+end
+
+function CVodeRootInit(cvode_mem::Ptr{Void},nrtfn::Int,g::CVRootFn)
+    ccall((:CVodeRootInit,libsundials_cvode),Cint,(Ptr{Void},Cint,CVRootFn),cvode_mem,nrtfn,g)
+end
+
+function CVode(cvode_mem::Ptr{Void},tout::realtype,yout::N_Vector,tret::Vector{realtype},itask::Int)
+    ccall((:CVode,libsundials_cvode),Cint,(Ptr{Void},realtype,N_Vector,Ptr{realtype},Cint),cvode_mem,tout,yout,tret,itask)
+end
+
+function CVodeGetDky(cvode_mem::Ptr{Void},t::realtype,k::Int,dky::N_Vector)
+    ccall((:CVodeGetDky,libsundials_cvode),Cint,(Ptr{Void},realtype,Cint,N_Vector),cvode_mem,t,k,dky)
+end
+
+function CVodeGetWorkSpace(cvode_mem::Ptr{Void},lenrw::Ptr{Clong},leniw::Ptr{Clong})
+    ccall((:CVodeGetWorkSpace,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,lenrw,leniw)
+end
+
+function CVodeGetNumSteps(cvode_mem::Ptr{Void},nsteps::Ptr{Clong})
+    ccall((:CVodeGetNumSteps,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nsteps)
+end
+
+function CVodeGetNumRhsEvals(cvode_mem::Ptr{Void},nfevals::Ptr{Clong})
+    ccall((:CVodeGetNumRhsEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nfevals)
+end
+
+function CVodeGetNumLinSolvSetups(cvode_mem::Ptr{Void},nlinsetups::Ptr{Clong})
+    ccall((:CVodeGetNumLinSolvSetups,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nlinsetups)
+end
+
+function CVodeGetNumErrTestFails(cvode_mem::Ptr{Void},netfails::Ptr{Clong})
+    ccall((:CVodeGetNumErrTestFails,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,netfails)
+end
+
+function CVodeGetLastOrder(cvode_mem::Ptr{Void},qlast::Ptr{Cint})
+    ccall((:CVodeGetLastOrder,libsundials_cvode),Cint,(Ptr{Void},Ptr{Cint}),cvode_mem,qlast)
+end
+
+function CVodeGetCurrentOrder(cvode_mem::Ptr{Void},qcur::Ptr{Cint})
+    ccall((:CVodeGetCurrentOrder,libsundials_cvode),Cint,(Ptr{Void},Ptr{Cint}),cvode_mem,qcur)
+end
+
+function CVodeGetNumStabLimOrderReds(cvode_mem::Ptr{Void},nslred::Ptr{Clong})
+    ccall((:CVodeGetNumStabLimOrderReds,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nslred)
+end
+
+function CVodeGetActualInitStep(cvode_mem::Ptr{Void},hinused::Vector{realtype})
+    ccall((:CVodeGetActualInitStep,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype}),cvode_mem,hinused)
+end
+
+function CVodeGetLastStep(cvode_mem::Ptr{Void},hlast::Vector{realtype})
+    ccall((:CVodeGetLastStep,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype}),cvode_mem,hlast)
+end
+
+function CVodeGetCurrentStep(cvode_mem::Ptr{Void},hcur::Vector{realtype})
+    ccall((:CVodeGetCurrentStep,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype}),cvode_mem,hcur)
+end
+
+function CVodeGetCurrentTime(cvode_mem::Ptr{Void},tcur::Vector{realtype})
+    ccall((:CVodeGetCurrentTime,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype}),cvode_mem,tcur)
+end
+
+function CVodeGetTolScaleFactor(cvode_mem::Ptr{Void},tolsfac::Vector{realtype})
+    ccall((:CVodeGetTolScaleFactor,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype}),cvode_mem,tolsfac)
+end
+
+function CVodeGetErrWeights(cvode_mem::Ptr{Void},eweight::N_Vector)
+    ccall((:CVodeGetErrWeights,libsundials_cvode),Cint,(Ptr{Void},N_Vector),cvode_mem,eweight)
+end
+
+function CVodeGetEstLocalErrors(cvode_mem::Ptr{Void},ele::N_Vector)
+    ccall((:CVodeGetEstLocalErrors,libsundials_cvode),Cint,(Ptr{Void},N_Vector),cvode_mem,ele)
+end
+
+function CVodeGetNumGEvals(cvode_mem::Ptr{Void},ngevals::Ptr{Clong})
+    ccall((:CVodeGetNumGEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,ngevals)
+end
+
+function CVodeGetRootInfo(cvode_mem::Ptr{Void},rootsfound::Ptr{Cint})
+    ccall((:CVodeGetRootInfo,libsundials_cvode),Cint,(Ptr{Void},Ptr{Cint}),cvode_mem,rootsfound)
+end
+
+function CVodeGetIntegratorStats(cvode_mem::Ptr{Void},nsteps::Ptr{Clong},nfevals::Ptr{Clong},nlinsetups::Ptr{Clong},netfails::Ptr{Clong},qlast::Ptr{Cint},qcur::Ptr{Cint},hinused::Vector{realtype},hlast::Vector{realtype},hcur::Vector{realtype},tcur::Vector{realtype})
+    ccall((:CVodeGetIntegratorStats,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Cint},Ptr{Cint},Ptr{realtype},Ptr{realtype},Ptr{realtype},Ptr{realtype}),cvode_mem,nsteps,nfevals,nlinsetups,netfails,qlast,qcur,hinused,hlast,hcur,tcur)
+end
+
+function CVodeGetNumNonlinSolvIters(cvode_mem::Ptr{Void},nniters::Ptr{Clong})
+    ccall((:CVodeGetNumNonlinSolvIters,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nniters)
+end
+
+function CVodeGetNumNonlinSolvConvFails(cvode_mem::Ptr{Void},nncfails::Ptr{Clong})
+    ccall((:CVodeGetNumNonlinSolvConvFails,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nncfails)
+end
+
+function CVodeGetNonlinSolvStats(cvode_mem::Ptr{Void},nniters::Ptr{Clong},nncfails::Ptr{Clong})
+    ccall((:CVodeGetNonlinSolvStats,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,nniters,nncfails)
+end
+
+function CVodeGetReturnFlagName(flag::Int)
+    ccall((:CVodeGetReturnFlagName,libsundials_cvode),Ptr{UInt8},(Clong,),flag)
+end
+
+function CVodeFree(cvode_mem::Vector{Ptr{Void}})
+    ccall((:CVodeFree,libsundials_cvode),Void,(Ptr{Ptr{Void}},),cvode_mem)
+end
+
+function CVEwtSet(ycur::N_Vector,weight::N_Vector,data::Ptr{Void})
+    ccall((:CVEwtSet,libsundials_cvode),Cint,(N_Vector,N_Vector,Ptr{Void}),ycur,weight,data)
+end
+
+function CVErrHandler(error_code::Int,_module::Ptr{UInt8},_function::Ptr{UInt8},msg::Ptr{UInt8},data::Ptr{Void})
+    ccall((:CVErrHandler,libsundials_cvode),Void,(Cint,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},Ptr{Void}),error_code,_module,_function,msg,data)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvode/cvode_spbcgs.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function SpbcgMalloc(l_max::Int,vec_tmpl::N_Vector)
+    ccall((:SpbcgMalloc,libsundials_cvode),SpbcgMem,(Cint,N_Vector),l_max,vec_tmpl)
+end
+
+function SpbcgSolve(mem::SpbcgMem,A_data::Ptr{Void},x::N_Vector,b::N_Vector,pretype::Int,delta::realtype,P_data::Ptr{Void},sx::N_Vector,sb::N_Vector,atimes::ATimesFn,psolve::PSolveFn,res_norm::Vector{realtype},nli::Ptr{Cint},nps::Ptr{Cint})
+    ccall((:SpbcgSolve,libsundials_cvode),Cint,(SpbcgMem,Ptr{Void},N_Vector,N_Vector,Cint,realtype,Ptr{Void},N_Vector,N_Vector,ATimesFn,PSolveFn,Ptr{realtype},Ptr{Cint},Ptr{Cint}),mem,A_data,x,b,pretype,delta,P_data,sx,sb,atimes,psolve,res_norm,nli,nps)
+end
+
+function SpbcgFree(mem::SpbcgMem)
+    ccall((:SpbcgFree,libsundials_cvode),Void,(SpbcgMem,),mem)
+end
+
+function CVSpbcg(cvode_mem::Ptr{Void},pretype::Int,maxl::Int)
+    ccall((:CVSpbcg,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint),cvode_mem,pretype,maxl)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvode/cvode_spgmr.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function SpgmrMalloc(l_max::Int,vec_tmpl::N_Vector)
+    ccall((:SpgmrMalloc,libsundials_cvode),SpgmrMem,(Cint,N_Vector),l_max,vec_tmpl)
+end
+
+function SpgmrSolve(mem::SpgmrMem,A_data::Ptr{Void},x::N_Vector,b::N_Vector,pretype::Int,gstype::Int,delta::realtype,max_restarts::Int,P_data::Ptr{Void},s1::N_Vector,s2::N_Vector,atimes::ATimesFn,psolve::PSolveFn,res_norm::Vector{realtype},nli::Ptr{Cint},nps::Ptr{Cint})
+    ccall((:SpgmrSolve,libsundials_cvode),Cint,(SpgmrMem,Ptr{Void},N_Vector,N_Vector,Cint,Cint,realtype,Cint,Ptr{Void},N_Vector,N_Vector,ATimesFn,PSolveFn,Ptr{realtype},Ptr{Cint},Ptr{Cint}),mem,A_data,x,b,pretype,gstype,delta,max_restarts,P_data,s1,s2,atimes,psolve,res_norm,nli,nps)
+end
+
+function SpgmrFree(mem::SpgmrMem)
+    ccall((:SpgmrFree,libsundials_cvode),Void,(SpgmrMem,),mem)
+end
+
+function CVSpgmr(cvode_mem::Ptr{Void},pretype::Int,maxl::Int)
+    ccall((:CVSpgmr,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint),cvode_mem,pretype,maxl)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvode/cvode_sptfqmr.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+
+function SptfqmrMalloc(l_max::Int,vec_tmpl::N_Vector)
+    ccall((:SptfqmrMalloc,libsundials_cvode),SptfqmrMem,(Cint,N_Vector),l_max,vec_tmpl)
+end
+
+function SptfqmrSolve(mem::SptfqmrMem,A_data::Ptr{Void},x::N_Vector,b::N_Vector,pretype::Int,delta::realtype,P_data::Ptr{Void},sx::N_Vector,sb::N_Vector,atimes::ATimesFn,psolve::PSolveFn,res_norm::Vector{realtype},nli::Ptr{Cint},nps::Ptr{Cint})
+    ccall((:SptfqmrSolve,libsundials_cvode),Cint,(SptfqmrMem,Ptr{Void},N_Vector,N_Vector,Cint,realtype,Ptr{Void},N_Vector,N_Vector,ATimesFn,PSolveFn,Ptr{realtype},Ptr{Cint},Ptr{Cint}),mem,A_data,x,b,pretype,delta,P_data,sx,sb,atimes,psolve,res_norm,nli,nps)
+end
+
+function SptfqmrFree(mem::SptfqmrMem)
+    ccall((:SptfqmrFree,libsundials_cvode),Void,(SptfqmrMem,),mem)
+end
+
+function CVSptfqmr(cvode_mem::Ptr{Void},pretype::Int,maxl::Int)
+    ccall((:CVSptfqmr,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint),cvode_mem,pretype,maxl)
+end

--- a/src/cvodes.jl
+++ b/src/cvodes.jl
@@ -1,182 +1,1373 @@
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvodes/cvodes.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
 
-recurs_sym_type(ex::Any) = 
-  (ex==None || typeof(ex)==Symbol || length(ex.args)==1) ? eval(ex) : Expr(ex.head, ex.args[1], recurs_sym_type(ex.args[2]))
-macro c(ret_type, func, arg_types, lib)
-  local _arg_types = Expr(:tuple, [recurs_sym_type(a) for a in arg_types.args]...)
-  local _ret_type = recurs_sym_type(ret_type)
-  local _args_in = Any[ symbol(string('a',x)) for x in 1:length(_arg_types.args) ]
-  local _lib = eval(lib)
-  quote
-    $(esc(func))($(_args_in...)) = ccall( ($(string(func)), $(Expr(:quote, _lib)) ), $_ret_type, $_arg_types, $(_args_in...) )
-  end
+
+function CVodeCreate(lmm::Int,iter::Int)
+    ccall((:CVodeCreate,libsundials_cvode),Ptr{Void},(Cint,Cint),lmm,iter)
 end
 
-macro ctypedef(fake_t,real_t)
-  real_t = recurs_sym_type(real_t)
-  quote
-    typealias $fake_t $real_t
-  end
+function CVodeInit(cvode_mem::Ptr{Void},f::CVRhsFn,t0::realtype,y0::N_Vector)
+    ccall((:CVodeInit,libsundials_cvode),Cint,(Ptr{Void},CVRhsFn,realtype,N_Vector),cvode_mem,f,t0,y0)
 end
 
-# header: /usr/local/include/cvodes/cvodes_band.h
-@ctypedef CVDlsDenseJacFnB Ptr{:Void}
-@ctypedef CVDlsBandJacFnB Ptr{:Void}
-@c Int32 CVDlsSetDenseJacFnB (Ptr{:None},:Int32,:CVDlsDenseJacFnB) shlib
-@c Int32 CVDlsSetBandJacFnB (Ptr{:None},:Int32,:CVDlsBandJacFnB) shlib
-@c Int32 CVBandB (Ptr{:None},:Int32,:Clong,:Clong,:Clong) shlib
+function CVodeReInit(cvode_mem::Ptr{Void},t0::realtype,y0::N_Vector)
+    ccall((:CVodeReInit,libsundials_cvode),Cint,(Ptr{Void},realtype,N_Vector),cvode_mem,t0,y0)
+end
 
-# header: /usr/local/include/cvodes/cvodes_bandpre.h
-@c Int32 CVBandPrecInitB (Ptr{:None},:Int32,:Clong,:Clong,:Clong) shlib
+function CVodeSStolerances(cvode_mem::Ptr{Void},reltol::realtype,abstol::realtype)
+    ccall((:CVodeSStolerances,libsundials_cvode),Cint,(Ptr{Void},realtype,realtype),cvode_mem,reltol,abstol)
+end
 
-# header: /usr/local/include/cvodes/cvodes_bbdpre.h
-@ctypedef CVLocalFnB Ptr{:Void}
-@ctypedef CVCommFnB Ptr{:Void}
-@c Int32 CVBBDPrecInitB (Ptr{:None},:Int32,:Clong,:Clong,:Clong,:Clong,:Clong,:realtype,:CVLocalFnB,:CVCommFnB) shlib
-@c Int32 CVBBDPrecReInitB (Ptr{:None},:Int32,:Clong,:Clong,:realtype) shlib
+function CVodeSVtolerances(cvode_mem::Ptr{Void},reltol::realtype,abstol::N_Vector)
+    ccall((:CVodeSVtolerances,libsundials_cvode),Cint,(Ptr{Void},realtype,N_Vector),cvode_mem,reltol,abstol)
+end
 
-# header: /usr/local/include/cvodes/cvodes_dense.h
-@c Int32 CVDenseB (Ptr{:None},:Int32,:Clong) shlib
+function CVodeWFtolerances(cvode_mem::Ptr{Void},efun::CVEwtFn)
+    ccall((:CVodeWFtolerances,libsundials_cvode),Cint,(Ptr{Void},CVEwtFn),cvode_mem,efun)
+end
 
-# header: /usr/local/include/cvodes/cvodes_diag.h
-@c Int32 CVDiagB (Ptr{:None},:Int32) shlib
+function CVodeQuadInit(cvode_mem::Ptr{Void},fQ::CVQuadRhsFn,yQ0::N_Vector)
+    ccall((:CVodeQuadInit,libsundials_cvode),Cint,(Ptr{Void},CVQuadRhsFn,N_Vector),cvode_mem,fQ,yQ0)
+end
 
-# header: /usr/local/include/cvodes/cvodes_direct.h
+function CVodeQuadReInit(cvode_mem::Ptr{Void},yQ0::N_Vector)
+    ccall((:CVodeQuadReInit,libsundials_cvode),Cint,(Ptr{Void},N_Vector),cvode_mem,yQ0)
+end
 
-# header: /usr/local/include/cvodes/cvodes.h
-@ctypedef CVQuadRhsFn Ptr{:Void}
-@ctypedef CVSensRhsFn Ptr{:Void}
-@ctypedef CVSensRhs1Fn Ptr{:Void}
-@ctypedef CVQuadSensRhsFn Ptr{:Void}
-@ctypedef CVRhsFnB Ptr{:Void}
-@ctypedef CVRhsFnBS Ptr{:Void}
-@ctypedef CVQuadRhsFnB Ptr{:Void}
-@ctypedef CVQuadRhsFnBS Ptr{:Void}
-@c Int32 CVodeQuadInit (Ptr{:None},:CVQuadRhsFn,:N_Vector) shlib
-@c Int32 CVodeQuadReInit (Ptr{:None},:N_Vector) shlib
-@c Int32 CVodeQuadSStolerances (Ptr{:None},:realtype,:realtype) shlib
-@c Int32 CVodeQuadSVtolerances (Ptr{:None},:realtype,:N_Vector) shlib
-@c Int32 CVodeSensInit (Ptr{:None},:Int32,:Int32,:CVSensRhsFn,Ptr{:N_Vector}) shlib
-@c Int32 CVodeSensInit1 (Ptr{:None},:Int32,:Int32,:CVSensRhs1Fn,Ptr{:N_Vector}) shlib
-@c Int32 CVodeSensReInit (Ptr{:None},:Int32,Ptr{:N_Vector}) shlib
-@c Int32 CVodeSensSStolerances (Ptr{:None},:realtype,Ptr{:realtype}) shlib
-@c Int32 CVodeSensSVtolerances (Ptr{:None},:realtype,Ptr{:N_Vector}) shlib
-@c Int32 CVodeSensEEtolerances (Ptr{:None},) shlib
-@c Int32 CVodeQuadSensInit (Ptr{:None},:CVQuadSensRhsFn,Ptr{:N_Vector}) shlib
-@c Int32 CVodeQuadSensReInit (Ptr{:None},Ptr{:N_Vector}) shlib
-@c Int32 CVodeQuadSensSStolerances (Ptr{:None},:realtype,Ptr{:realtype}) shlib
-@c Int32 CVodeQuadSensSVtolerances (Ptr{:None},:realtype,Ptr{:N_Vector}) shlib
-@c Int32 CVodeQuadSensEEtolerances (Ptr{:None},) shlib
-@c None CVodeQuadFree (Ptr{:None},) shlib
-@c None CVodeSensFree (Ptr{:None},) shlib
-@c None CVodeQuadSensFree (Ptr{:None},) shlib
-@c Int32 CVodeSetQuadErrCon (Ptr{:None},:Int32) shlib
-@c Int32 CVodeSetSensDQMethod (Ptr{:None},:Int32,:realtype) shlib
-@c Int32 CVodeSetSensErrCon (Ptr{:None},:Int32) shlib
-@c Int32 CVodeSetSensMaxNonlinIters (Ptr{:None},:Int32) shlib
-@c Int32 CVodeSetSensParams (Ptr{:None},Ptr{:realtype},Ptr{:realtype},Ptr{:Int32}) shlib
-@c Int32 CVodeSetQuadSensErrCon (Ptr{:None},:Int32) shlib
-@c Int32 CVodeSensToggleOff (Ptr{:None},) shlib
-@c Int32 CVodeGetQuad (Ptr{:None},Ptr{:realtype},:N_Vector) shlib
-@c Int32 CVodeGetQuadDky (Ptr{:None},:realtype,:Int32,:N_Vector) shlib
-@c Int32 CVodeGetSens (Ptr{:None},Ptr{:realtype},Ptr{:N_Vector}) shlib
-@c Int32 CVodeGetSens1 (Ptr{:None},Ptr{:realtype},:Int32,:N_Vector) shlib
-@c Int32 CVodeGetSensDky (Ptr{:None},:realtype,:Int32,Ptr{:N_Vector}) shlib
-@c Int32 CVodeGetSensDky1 (Ptr{:None},:realtype,:Int32,:Int32,:N_Vector) shlib
-@c Int32 CVodeGetQuadSens (Ptr{:None},Ptr{:realtype},Ptr{:N_Vector}) shlib
-@c Int32 CVodeGetQuadSens1 (Ptr{:None},Ptr{:realtype},:Int32,:N_Vector) shlib
-@c Int32 CVodeGetQuadSensDky (Ptr{:None},:realtype,:Int32,Ptr{:N_Vector}) shlib
-@c Int32 CVodeGetQuadSensDky1 (Ptr{:None},:realtype,:Int32,:Int32,:N_Vector) shlib
-@c Int32 CVodeGetQuadNumRhsEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVodeGetQuadNumErrTestFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVodeGetQuadErrWeights (Ptr{:None},:N_Vector) shlib
-@c Int32 CVodeGetQuadStats (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 CVodeGetSensNumRhsEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVodeGetNumRhsEvalsSens (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVodeGetSensNumErrTestFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVodeGetSensNumLinSolvSetups (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVodeGetSensErrWeights (Ptr{:None},Ptr{:N_Vector}) shlib
-@c Int32 CVodeGetSensStats (Ptr{:None},Ptr{:Clong},Ptr{:Clong},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 CVodeGetSensNumNonlinSolvIters (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVodeGetSensNumNonlinSolvConvFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVodeGetStgrSensNumNonlinSolvIters (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVodeGetStgrSensNumNonlinSolvConvFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVodeGetSensNonlinSolvStats (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 CVodeGetQuadSensNumRhsEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVodeGetQuadSensNumErrTestFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 CVodeGetQuadSensErrWeights (Ptr{:None},Ptr{:N_Vector}) shlib
-@c Int32 CVodeGetQuadSensStats (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 CVodeAdjInit (Ptr{:None},:Clong,:Int32) shlib
-@c Int32 CVodeAdjReInit (Ptr{:None},) shlib
-@c None CVodeAdjFree (Ptr{:None},) shlib
-@c Int32 CVodeCreateB (Ptr{:None},:Int32,:Int32,Ptr{:Int32}) shlib
-@c Int32 CVodeInitB (Ptr{:None},:Int32,:CVRhsFnB,:realtype,:N_Vector) shlib
-@c Int32 CVodeInitBS (Ptr{:None},:Int32,:CVRhsFnBS,:realtype,:N_Vector) shlib
-@c Int32 CVodeReInitB (Ptr{:None},:Int32,:realtype,:N_Vector) shlib
-@c Int32 CVodeSStolerancesB (Ptr{:None},:Int32,:realtype,:realtype) shlib
-@c Int32 CVodeSVtolerancesB (Ptr{:None},:Int32,:realtype,:N_Vector) shlib
-@c Int32 CVodeQuadInitB (Ptr{:None},:Int32,:CVQuadRhsFnB,:N_Vector) shlib
-@c Int32 CVodeQuadInitBS (Ptr{:None},:Int32,:CVQuadRhsFnBS,:N_Vector) shlib
-@c Int32 CVodeQuadReInitB (Ptr{:None},:Int32,:N_Vector) shlib
-@c Int32 CVodeQuadSStolerancesB (Ptr{:None},:Int32,:realtype,:realtype) shlib
-@c Int32 CVodeQuadSVtolerancesB (Ptr{:None},:Int32,:realtype,:N_Vector) shlib
-@c Int32 CVodeF (Ptr{:None},:realtype,:N_Vector,Ptr{:realtype},:Int32,Ptr{:Int32}) shlib
-@c Int32 CVodeB (Ptr{:None},:realtype,:Int32) shlib
-@c Int32 CVodeSetAdjNoSensi (Ptr{:None},) shlib
-@c Int32 CVodeSetIterTypeB (Ptr{:None},:Int32,:Int32) shlib
-@c Int32 CVodeSetUserDataB (Ptr{:None},:Int32,Ptr{:None}) shlib
-@c Int32 CVodeSetMaxOrdB (Ptr{:None},:Int32,:Int32) shlib
-@c Int32 CVodeSetMaxNumStepsB (Ptr{:None},:Int32,:Clong) shlib
-@c Int32 CVodeSetStabLimDetB (Ptr{:None},:Int32,:Int32) shlib
-@c Int32 CVodeSetInitStepB (Ptr{:None},:Int32,:realtype) shlib
-@c Int32 CVodeSetMinStepB (Ptr{:None},:Int32,:realtype) shlib
-@c Int32 CVodeSetMaxStepB (Ptr{:None},:Int32,:realtype) shlib
-@c Int32 CVodeSetQuadErrConB (Ptr{:None},:Int32,:Int32) shlib
-@c Int32 CVodeGetB (Ptr{:None},:Int32,Ptr{:realtype},:N_Vector) shlib
-@c Int32 CVodeGetQuadB (Ptr{:None},:Int32,Ptr{:realtype},:N_Vector) shlib
-@c Ptr{:None} CVodeGetAdjCVodeBmem (Ptr{:None},:Int32) shlib
-@c Int32 CVodeGetAdjY (Ptr{:None},:realtype,:N_Vector) shlib
-@ctypedef CVadjCheckPointRec Void
-@c Int32 CVodeGetAdjCheckPointsInfo (Ptr{:None},Ptr{:CVadjCheckPointRec}) shlib
-@c Int32 CVodeGetAdjDataPointHermite (Ptr{:None},:Int32,Ptr{:realtype},:N_Vector,:N_Vector) shlib
-@c Int32 CVodeGetAdjDataPointPolynomial (Ptr{:None},:Int32,Ptr{:realtype},Ptr{:Int32},:N_Vector) shlib
-@c Int32 CVodeGetAdjCurrentCheckPoint (Ptr{:None},Ptr{Ptr{:None}}) shlib
+function CVodeQuadSStolerances(cvode_mem::Ptr{Void},reltolQ::realtype,abstolQ::realtype)
+    ccall((:CVodeQuadSStolerances,libsundials_cvode),Cint,(Ptr{Void},realtype,realtype),cvode_mem,reltolQ,abstolQ)
+end
 
-# header: /usr/local/include/cvodes/cvodes_impl.h
-@ctypedef CVadjMem Ptr{:Void}
-@ctypedef CkpntMem Ptr{:Void}
-@ctypedef DtpntMem Ptr{:Void}
-@ctypedef CVodeBMem Ptr{:Void}
-@ctypedef cvaIMMallocFn Ptr{:Void}
-@ctypedef cvaIMFreeFn Ptr{:Void}
-@ctypedef cvaIMGetYFn Ptr{:Void}
-@ctypedef cvaIMStorePntFn Ptr{:Void}
-@ctypedef HermiteDataMem Ptr{:Void}
-@ctypedef PolynomialDataMem Ptr{:Void}
-@c Int32 cvEwtSet (:N_Vector,:N_Vector,Ptr{:None}) shlib
-@c None cvProcessError (:CVodeMem,:Int32,Ptr{:Uint8},Ptr{:Uint8},Ptr{:Uint8}) shlib
-@c None cvErrHandler (:Int32,Ptr{:Uint8},Ptr{:Uint8},Ptr{:Uint8},Ptr{:None}) shlib
-@c Int32 cvSensRhsWrapper (:CVodeMem,:realtype,:N_Vector,:N_Vector,Ptr{:N_Vector},Ptr{:N_Vector},:N_Vector,:N_Vector) shlib
-@c Int32 cvSensRhs1Wrapper (:CVodeMem,:realtype,:N_Vector,:N_Vector,:Int32,:N_Vector,:N_Vector,:N_Vector,:N_Vector) shlib
-@c Int32 cvSensRhsInternalDQ (:Int32,:realtype,:N_Vector,:N_Vector,Ptr{:N_Vector},Ptr{:N_Vector},Ptr{:None},:N_Vector,:N_Vector) shlib
-@c Int32 cvSensRhs1InternalDQ (:Int32,:realtype,:N_Vector,:N_Vector,:Int32,:N_Vector,:N_Vector,Ptr{:None},:N_Vector,:N_Vector) shlib
+function CVodeQuadSVtolerances(cvode_mem::Ptr{Void},reltolQ::realtype,abstolQ::N_Vector)
+    ccall((:CVodeQuadSVtolerances,libsundials_cvode),Cint,(Ptr{Void},realtype,N_Vector),cvode_mem,reltolQ,abstolQ)
+end
 
-# header: /usr/local/include/cvodes/cvodes_spbcgs.h
-@ctypedef CVSpilsPrecSetupFnB Ptr{:Void}
-@ctypedef CVSpilsPrecSolveFnB Ptr{:Void}
-@ctypedef CVSpilsJacTimesVecFnB Ptr{:Void}
-@c Int32 CVSpilsSetPrecTypeB (Ptr{:None},:Int32,:Int32) shlib
-@c Int32 CVSpilsSetGSTypeB (Ptr{:None},:Int32,:Int32) shlib
-@c Int32 CVSpilsSetEpslinB (Ptr{:None},:Int32,:realtype) shlib
-@c Int32 CVSpilsSetMaxlB (Ptr{:None},:Int32,:Int32) shlib
-@c Int32 CVSpilsSetPreconditionerB (Ptr{:None},:Int32,:CVSpilsPrecSetupFnB,:CVSpilsPrecSolveFnB) shlib
-@c Int32 CVSpilsSetJacTimesVecFnB (Ptr{:None},:Int32,:CVSpilsJacTimesVecFnB) shlib
-@c Int32 CVSpbcgB (Ptr{:None},:Int32,:Int32,:Int32) shlib
+function CVodeSensInit(cvode_mem::Ptr{Void},Ns::Int,ism::Int,fS::CVSensRhsFn,yS0::Ptr{N_Vector})
+    ccall((:CVodeSensInit,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint,CVSensRhsFn,Ptr{N_Vector}),cvode_mem,Ns,ism,fS,yS0)
+end
 
-# header: /usr/local/include/cvodes/cvodes_spgmr.h
-@c Int32 CVSpgmrB (Ptr{:None},:Int32,:Int32,:Int32) shlib
+function CVodeSensInit1(cvode_mem::Ptr{Void},Ns::Int,ism::Int,fS1::CVSensRhs1Fn,yS0::Ptr{N_Vector})
+    ccall((:CVodeSensInit1,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint,CVSensRhs1Fn,Ptr{N_Vector}),cvode_mem,Ns,ism,fS1,yS0)
+end
 
-# header: /usr/local/include/cvodes/cvodes_spils.h
+function CVodeSensReInit(cvode_mem::Ptr{Void},ism::Int,yS0::Ptr{N_Vector})
+    ccall((:CVodeSensReInit,libsundials_cvode),Cint,(Ptr{Void},Cint,Ptr{N_Vector}),cvode_mem,ism,yS0)
+end
 
-# header: /usr/local/include/cvodes/cvodes_sptfqmr.h
-@c Int32 CVSptfqmrB (Ptr{:None},:Int32,:Int32,:Int32) shlib
+function CVodeSensSStolerances(cvode_mem::Ptr{Void},reltolS::realtype,abstolS::Vector{realtype})
+    ccall((:CVodeSensSStolerances,libsundials_cvode),Cint,(Ptr{Void},realtype,Ptr{realtype}),cvode_mem,reltolS,abstolS)
+end
 
+function CVodeSensSVtolerances(cvode_mem::Ptr{Void},reltolS::realtype,abstolS::Ptr{N_Vector})
+    ccall((:CVodeSensSVtolerances,libsundials_cvode),Cint,(Ptr{Void},realtype,Ptr{N_Vector}),cvode_mem,reltolS,abstolS)
+end
+
+function CVodeSensEEtolerances(cvode_mem::Ptr{Void})
+    ccall((:CVodeSensEEtolerances,libsundials_cvode),Cint,(Ptr{Void},),cvode_mem)
+end
+
+function CVodeQuadSensInit(cvode_mem::Ptr{Void},fQS::CVQuadSensRhsFn,yQS0::Ptr{N_Vector})
+    ccall((:CVodeQuadSensInit,libsundials_cvode),Cint,(Ptr{Void},CVQuadSensRhsFn,Ptr{N_Vector}),cvode_mem,fQS,yQS0)
+end
+
+function CVodeQuadSensReInit(cvode_mem::Ptr{Void},yQS0::Ptr{N_Vector})
+    ccall((:CVodeQuadSensReInit,libsundials_cvode),Cint,(Ptr{Void},Ptr{N_Vector}),cvode_mem,yQS0)
+end
+
+function CVodeQuadSensSStolerances(cvode_mem::Ptr{Void},reltolQS::realtype,abstolQS::Vector{realtype})
+    ccall((:CVodeQuadSensSStolerances,libsundials_cvode),Cint,(Ptr{Void},realtype,Ptr{realtype}),cvode_mem,reltolQS,abstolQS)
+end
+
+function CVodeQuadSensSVtolerances(cvode_mem::Ptr{Void},reltolQS::realtype,abstolQS::Ptr{N_Vector})
+    ccall((:CVodeQuadSensSVtolerances,libsundials_cvode),Cint,(Ptr{Void},realtype,Ptr{N_Vector}),cvode_mem,reltolQS,abstolQS)
+end
+
+function CVodeQuadSensEEtolerances(cvode_mem::Ptr{Void})
+    ccall((:CVodeQuadSensEEtolerances,libsundials_cvode),Cint,(Ptr{Void},),cvode_mem)
+end
+
+function CVodeRootInit(cvode_mem::Ptr{Void},nrtfn::Int,g::CVRootFn)
+    ccall((:CVodeRootInit,libsundials_cvode),Cint,(Ptr{Void},Cint,CVRootFn),cvode_mem,nrtfn,g)
+end
+
+function CVodeFree(cvode_mem::Vector{Ptr{Void}})
+    ccall((:CVodeFree,libsundials_cvode),Void,(Ptr{Ptr{Void}},),cvode_mem)
+end
+
+function CVodeQuadFree(cvode_mem::Ptr{Void})
+    ccall((:CVodeQuadFree,libsundials_cvode),Void,(Ptr{Void},),cvode_mem)
+end
+
+function CVodeSensFree(cvode_mem::Ptr{Void})
+    ccall((:CVodeSensFree,libsundials_cvode),Void,(Ptr{Void},),cvode_mem)
+end
+
+function CVodeQuadSensFree(cvode_mem::Ptr{Void})
+    ccall((:CVodeQuadSensFree,libsundials_cvode),Void,(Ptr{Void},),cvode_mem)
+end
+
+function CVodeSetErrHandlerFn(cvode_mem::Ptr{Void},ehfun::CVErrHandlerFn,eh_data::Ptr{Void})
+    ccall((:CVodeSetErrHandlerFn,libsundials_cvode),Cint,(Ptr{Void},CVErrHandlerFn,Ptr{Void}),cvode_mem,ehfun,eh_data)
+end
+
+function CVodeSetErrFile(cvode_mem::Ptr{Void},errfp::Ptr{Void})
+    ccall((:CVodeSetErrFile,libsundials_cvode),Cint,(Ptr{Void},Ptr{Void}),cvode_mem,errfp)
+end
+# function CVodeSetErrFile(cvode_mem::Ptr{Void},errfp::Ptr{Void})
+#     ccall((:CVodeSetErrFile,libsundials_cvode),Cint,(Ptr{Void},Ptr{Void}),cvode_mem,errfp)
+# end
+
+function CVodeSetUserData(cvode_mem::Ptr{Void},user_data::Ptr{Void})
+    ccall((:CVodeSetUserData,libsundials_cvode),Cint,(Ptr{Void},Ptr{Void}),cvode_mem,user_data)
+end
+
+function CVodeSetMaxOrd(cvode_mem::Ptr{Void},maxord::Int)
+    ccall((:CVodeSetMaxOrd,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,maxord)
+end
+
+function CVodeSetMaxNumSteps(cvode_mem::Ptr{Void},mxsteps::Int)
+    ccall((:CVodeSetMaxNumSteps,libsundials_cvode),Cint,(Ptr{Void},Clong),cvode_mem,mxsteps)
+end
+
+function CVodeSetMaxHnilWarns(cvode_mem::Ptr{Void},mxhnil::Int)
+    ccall((:CVodeSetMaxHnilWarns,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,mxhnil)
+end
+
+function CVodeSetStabLimDet(cvode_mem::Ptr{Void},stldet::Int)
+    ccall((:CVodeSetStabLimDet,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,stldet)
+end
+
+function CVodeSetInitStep(cvode_mem::Ptr{Void},hin::realtype)
+    ccall((:CVodeSetInitStep,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,hin)
+end
+
+function CVodeSetMinStep(cvode_mem::Ptr{Void},hmin::realtype)
+    ccall((:CVodeSetMinStep,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,hmin)
+end
+
+function CVodeSetMaxStep(cvode_mem::Ptr{Void},hmax::realtype)
+    ccall((:CVodeSetMaxStep,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,hmax)
+end
+
+function CVodeSetStopTime(cvode_mem::Ptr{Void},tstop::realtype)
+    ccall((:CVodeSetStopTime,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,tstop)
+end
+
+function CVodeSetMaxErrTestFails(cvode_mem::Ptr{Void},maxnef::Int)
+    ccall((:CVodeSetMaxErrTestFails,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,maxnef)
+end
+
+function CVodeSetMaxNonlinIters(cvode_mem::Ptr{Void},maxcor::Int)
+    ccall((:CVodeSetMaxNonlinIters,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,maxcor)
+end
+
+function CVodeSetMaxConvFails(cvode_mem::Ptr{Void},maxncf::Int)
+    ccall((:CVodeSetMaxConvFails,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,maxncf)
+end
+
+function CVodeSetNonlinConvCoef(cvode_mem::Ptr{Void},nlscoef::realtype)
+    ccall((:CVodeSetNonlinConvCoef,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,nlscoef)
+end
+
+function CVodeSetIterType(cvode_mem::Ptr{Void},iter::Int)
+    ccall((:CVodeSetIterType,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,iter)
+end
+
+function CVodeSetRootDirection(cvode_mem::Ptr{Void},rootdir::Ptr{Cint})
+    ccall((:CVodeSetRootDirection,libsundials_cvode),Cint,(Ptr{Void},Ptr{Cint}),cvode_mem,rootdir)
+end
+
+function CVodeSetNoInactiveRootWarn(cvode_mem::Ptr{Void})
+    ccall((:CVodeSetNoInactiveRootWarn,libsundials_cvode),Cint,(Ptr{Void},),cvode_mem)
+end
+
+function CVodeSetQuadErrCon(cvode_mem::Ptr{Void},errconQ::Int)
+    ccall((:CVodeSetQuadErrCon,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,errconQ)
+end
+
+function CVodeSetSensDQMethod(cvode_mem::Ptr{Void},DQtype::Int,DQrhomax::realtype)
+    ccall((:CVodeSetSensDQMethod,libsundials_cvode),Cint,(Ptr{Void},Cint,realtype),cvode_mem,DQtype,DQrhomax)
+end
+
+function CVodeSetSensErrCon(cvode_mem::Ptr{Void},errconS::Int)
+    ccall((:CVodeSetSensErrCon,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,errconS)
+end
+
+function CVodeSetSensMaxNonlinIters(cvode_mem::Ptr{Void},maxcorS::Int)
+    ccall((:CVodeSetSensMaxNonlinIters,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,maxcorS)
+end
+
+function CVodeSetSensParams(cvode_mem::Ptr{Void},p::Vector{realtype},pbar::Vector{realtype},plist::Ptr{Cint})
+    ccall((:CVodeSetSensParams,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype},Ptr{realtype},Ptr{Cint}),cvode_mem,p,pbar,plist)
+end
+
+function CVodeSetQuadSensErrCon(cvode_mem::Ptr{Void},errconQS::Int)
+    ccall((:CVodeSetQuadSensErrCon,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,errconQS)
+end
+
+function CVodeSensToggleOff(cvode_mem::Ptr{Void})
+    ccall((:CVodeSensToggleOff,libsundials_cvode),Cint,(Ptr{Void},),cvode_mem)
+end
+
+function CVode(cvode_mem::Ptr{Void},tout::realtype,yout::N_Vector,tret::Vector{realtype},itask::Int)
+    ccall((:CVode,libsundials_cvode),Cint,(Ptr{Void},realtype,N_Vector,Ptr{realtype},Cint),cvode_mem,tout,yout,tret,itask)
+end
+
+function CVodeGetDky(cvode_mem::Ptr{Void},t::realtype,k::Int,dky::N_Vector)
+    ccall((:CVodeGetDky,libsundials_cvode),Cint,(Ptr{Void},realtype,Cint,N_Vector),cvode_mem,t,k,dky)
+end
+
+function CVodeGetQuad(cvode_mem::Ptr{Void},tret::Vector{realtype},yQout::N_Vector)
+    ccall((:CVodeGetQuad,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype},N_Vector),cvode_mem,tret,yQout)
+end
+
+function CVodeGetQuadDky(cvode_mem::Ptr{Void},t::realtype,k::Int,dky::N_Vector)
+    ccall((:CVodeGetQuadDky,libsundials_cvode),Cint,(Ptr{Void},realtype,Cint,N_Vector),cvode_mem,t,k,dky)
+end
+
+function CVodeGetSens(cvode_mem::Ptr{Void},tret::Vector{realtype},ySout::Ptr{N_Vector})
+    ccall((:CVodeGetSens,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype},Ptr{N_Vector}),cvode_mem,tret,ySout)
+end
+
+function CVodeGetSens1(cvode_mem::Ptr{Void},tret::Vector{realtype},is::Int,ySout::N_Vector)
+    ccall((:CVodeGetSens1,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype},Cint,N_Vector),cvode_mem,tret,is,ySout)
+end
+
+function CVodeGetSensDky(cvode_mem::Ptr{Void},t::realtype,k::Int,dkyA::Ptr{N_Vector})
+    ccall((:CVodeGetSensDky,libsundials_cvode),Cint,(Ptr{Void},realtype,Cint,Ptr{N_Vector}),cvode_mem,t,k,dkyA)
+end
+
+function CVodeGetSensDky1(cvode_mem::Ptr{Void},t::realtype,k::Int,is::Int,dky::N_Vector)
+    ccall((:CVodeGetSensDky1,libsundials_cvode),Cint,(Ptr{Void},realtype,Cint,Cint,N_Vector),cvode_mem,t,k,is,dky)
+end
+
+function CVodeGetQuadSens(cvode_mem::Ptr{Void},tret::Vector{realtype},yQSout::Ptr{N_Vector})
+    ccall((:CVodeGetQuadSens,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype},Ptr{N_Vector}),cvode_mem,tret,yQSout)
+end
+
+function CVodeGetQuadSens1(cvode_mem::Ptr{Void},tret::Vector{realtype},is::Int,yQSout::N_Vector)
+    ccall((:CVodeGetQuadSens1,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype},Cint,N_Vector),cvode_mem,tret,is,yQSout)
+end
+
+function CVodeGetQuadSensDky(cvode_mem::Ptr{Void},t::realtype,k::Int,dkyQS_all::Ptr{N_Vector})
+    ccall((:CVodeGetQuadSensDky,libsundials_cvode),Cint,(Ptr{Void},realtype,Cint,Ptr{N_Vector}),cvode_mem,t,k,dkyQS_all)
+end
+
+function CVodeGetQuadSensDky1(cvode_mem::Ptr{Void},t::realtype,k::Int,is::Int,dkyQS::N_Vector)
+    ccall((:CVodeGetQuadSensDky1,libsundials_cvode),Cint,(Ptr{Void},realtype,Cint,Cint,N_Vector),cvode_mem,t,k,is,dkyQS)
+end
+
+function CVodeGetWorkSpace(cvode_mem::Ptr{Void},lenrw::Ptr{Clong},leniw::Ptr{Clong})
+    ccall((:CVodeGetWorkSpace,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,lenrw,leniw)
+end
+
+function CVodeGetNumSteps(cvode_mem::Ptr{Void},nsteps::Ptr{Clong})
+    ccall((:CVodeGetNumSteps,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nsteps)
+end
+
+function CVodeGetNumRhsEvals(cvode_mem::Ptr{Void},nfevals::Ptr{Clong})
+    ccall((:CVodeGetNumRhsEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nfevals)
+end
+
+function CVodeGetNumLinSolvSetups(cvode_mem::Ptr{Void},nlinsetups::Ptr{Clong})
+    ccall((:CVodeGetNumLinSolvSetups,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nlinsetups)
+end
+
+function CVodeGetNumErrTestFails(cvode_mem::Ptr{Void},netfails::Ptr{Clong})
+    ccall((:CVodeGetNumErrTestFails,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,netfails)
+end
+
+function CVodeGetLastOrder(cvode_mem::Ptr{Void},qlast::Ptr{Cint})
+    ccall((:CVodeGetLastOrder,libsundials_cvode),Cint,(Ptr{Void},Ptr{Cint}),cvode_mem,qlast)
+end
+
+function CVodeGetCurrentOrder(cvode_mem::Ptr{Void},qcur::Ptr{Cint})
+    ccall((:CVodeGetCurrentOrder,libsundials_cvode),Cint,(Ptr{Void},Ptr{Cint}),cvode_mem,qcur)
+end
+
+function CVodeGetNumStabLimOrderReds(cvode_mem::Ptr{Void},nslred::Ptr{Clong})
+    ccall((:CVodeGetNumStabLimOrderReds,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nslred)
+end
+
+function CVodeGetActualInitStep(cvode_mem::Ptr{Void},hinused::Vector{realtype})
+    ccall((:CVodeGetActualInitStep,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype}),cvode_mem,hinused)
+end
+
+function CVodeGetLastStep(cvode_mem::Ptr{Void},hlast::Vector{realtype})
+    ccall((:CVodeGetLastStep,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype}),cvode_mem,hlast)
+end
+
+function CVodeGetCurrentStep(cvode_mem::Ptr{Void},hcur::Vector{realtype})
+    ccall((:CVodeGetCurrentStep,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype}),cvode_mem,hcur)
+end
+
+function CVodeGetCurrentTime(cvode_mem::Ptr{Void},tcur::Vector{realtype})
+    ccall((:CVodeGetCurrentTime,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype}),cvode_mem,tcur)
+end
+
+function CVodeGetTolScaleFactor(cvode_mem::Ptr{Void},tolsfac::Vector{realtype})
+    ccall((:CVodeGetTolScaleFactor,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype}),cvode_mem,tolsfac)
+end
+
+function CVodeGetErrWeights(cvode_mem::Ptr{Void},eweight::N_Vector)
+    ccall((:CVodeGetErrWeights,libsundials_cvode),Cint,(Ptr{Void},N_Vector),cvode_mem,eweight)
+end
+
+function CVodeGetEstLocalErrors(cvode_mem::Ptr{Void},ele::N_Vector)
+    ccall((:CVodeGetEstLocalErrors,libsundials_cvode),Cint,(Ptr{Void},N_Vector),cvode_mem,ele)
+end
+
+function CVodeGetNumGEvals(cvode_mem::Ptr{Void},ngevals::Ptr{Clong})
+    ccall((:CVodeGetNumGEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,ngevals)
+end
+
+function CVodeGetRootInfo(cvode_mem::Ptr{Void},rootsfound::Ptr{Cint})
+    ccall((:CVodeGetRootInfo,libsundials_cvode),Cint,(Ptr{Void},Ptr{Cint}),cvode_mem,rootsfound)
+end
+
+function CVodeGetIntegratorStats(cvode_mem::Ptr{Void},nsteps::Ptr{Clong},nfevals::Ptr{Clong},nlinsetups::Ptr{Clong},netfails::Ptr{Clong},qlast::Ptr{Cint},qcur::Ptr{Cint},hinused::Vector{realtype},hlast::Vector{realtype},hcur::Vector{realtype},tcur::Vector{realtype})
+    ccall((:CVodeGetIntegratorStats,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Cint},Ptr{Cint},Ptr{realtype},Ptr{realtype},Ptr{realtype},Ptr{realtype}),cvode_mem,nsteps,nfevals,nlinsetups,netfails,qlast,qcur,hinused,hlast,hcur,tcur)
+end
+
+function CVodeGetNumNonlinSolvIters(cvode_mem::Ptr{Void},nniters::Ptr{Clong})
+    ccall((:CVodeGetNumNonlinSolvIters,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nniters)
+end
+
+function CVodeGetNumNonlinSolvConvFails(cvode_mem::Ptr{Void},nncfails::Ptr{Clong})
+    ccall((:CVodeGetNumNonlinSolvConvFails,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nncfails)
+end
+
+function CVodeGetNonlinSolvStats(cvode_mem::Ptr{Void},nniters::Ptr{Clong},nncfails::Ptr{Clong})
+    ccall((:CVodeGetNonlinSolvStats,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,nniters,nncfails)
+end
+
+function CVodeGetReturnFlagName(flag::Int)
+    ccall((:CVodeGetReturnFlagName,libsundials_cvode),Ptr{UInt8},(Clong,),flag)
+end
+
+function CVodeGetQuadNumRhsEvals(cvode_mem::Ptr{Void},nfQevals::Ptr{Clong})
+    ccall((:CVodeGetQuadNumRhsEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nfQevals)
+end
+
+function CVodeGetQuadNumErrTestFails(cvode_mem::Ptr{Void},nQetfails::Ptr{Clong})
+    ccall((:CVodeGetQuadNumErrTestFails,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nQetfails)
+end
+
+function CVodeGetQuadErrWeights(cvode_mem::Ptr{Void},eQweight::N_Vector)
+    ccall((:CVodeGetQuadErrWeights,libsundials_cvode),Cint,(Ptr{Void},N_Vector),cvode_mem,eQweight)
+end
+
+function CVodeGetQuadStats(cvode_mem::Ptr{Void},nfQevals::Ptr{Clong},nQetfails::Ptr{Clong})
+    ccall((:CVodeGetQuadStats,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,nfQevals,nQetfails)
+end
+
+function CVodeGetSensNumRhsEvals(cvode_mem::Ptr{Void},nfSevals::Ptr{Clong})
+    ccall((:CVodeGetSensNumRhsEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nfSevals)
+end
+
+function CVodeGetNumRhsEvalsSens(cvode_mem::Ptr{Void},nfevalsS::Ptr{Clong})
+    ccall((:CVodeGetNumRhsEvalsSens,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nfevalsS)
+end
+
+function CVodeGetSensNumErrTestFails(cvode_mem::Ptr{Void},nSetfails::Ptr{Clong})
+    ccall((:CVodeGetSensNumErrTestFails,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nSetfails)
+end
+
+function CVodeGetSensNumLinSolvSetups(cvode_mem::Ptr{Void},nlinsetupsS::Ptr{Clong})
+    ccall((:CVodeGetSensNumLinSolvSetups,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nlinsetupsS)
+end
+
+function CVodeGetSensErrWeights(cvode_mem::Ptr{Void},eSweight::Ptr{N_Vector})
+    ccall((:CVodeGetSensErrWeights,libsundials_cvode),Cint,(Ptr{Void},Ptr{N_Vector}),cvode_mem,eSweight)
+end
+
+function CVodeGetSensStats(cvode_mem::Ptr{Void},nfSevals::Ptr{Clong},nfevalsS::Ptr{Clong},nSetfails::Ptr{Clong},nlinsetupsS::Ptr{Clong})
+    ccall((:CVodeGetSensStats,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Clong}),cvode_mem,nfSevals,nfevalsS,nSetfails,nlinsetupsS)
+end
+
+function CVodeGetSensNumNonlinSolvIters(cvode_mem::Ptr{Void},nSniters::Ptr{Clong})
+    ccall((:CVodeGetSensNumNonlinSolvIters,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nSniters)
+end
+
+function CVodeGetSensNumNonlinSolvConvFails(cvode_mem::Ptr{Void},nSncfails::Ptr{Clong})
+    ccall((:CVodeGetSensNumNonlinSolvConvFails,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nSncfails)
+end
+
+function CVodeGetStgrSensNumNonlinSolvIters(cvode_mem::Ptr{Void},nSTGR1niters::Ptr{Clong})
+    ccall((:CVodeGetStgrSensNumNonlinSolvIters,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nSTGR1niters)
+end
+
+function CVodeGetStgrSensNumNonlinSolvConvFails(cvode_mem::Ptr{Void},nSTGR1ncfails::Ptr{Clong})
+    ccall((:CVodeGetStgrSensNumNonlinSolvConvFails,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nSTGR1ncfails)
+end
+
+function CVodeGetSensNonlinSolvStats(cvode_mem::Ptr{Void},nSniters::Ptr{Clong},nSncfails::Ptr{Clong})
+    ccall((:CVodeGetSensNonlinSolvStats,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,nSniters,nSncfails)
+end
+
+function CVodeGetQuadSensNumRhsEvals(cvode_mem::Ptr{Void},nfQSevals::Ptr{Clong})
+    ccall((:CVodeGetQuadSensNumRhsEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nfQSevals)
+end
+
+function CVodeGetQuadSensNumErrTestFails(cvode_mem::Ptr{Void},nQSetfails::Ptr{Clong})
+    ccall((:CVodeGetQuadSensNumErrTestFails,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nQSetfails)
+end
+
+function CVodeGetQuadSensErrWeights(cvode_mem::Ptr{Void},eQSweight::Ptr{N_Vector})
+    ccall((:CVodeGetQuadSensErrWeights,libsundials_cvode),Cint,(Ptr{Void},Ptr{N_Vector}),cvode_mem,eQSweight)
+end
+
+function CVodeGetQuadSensStats(cvode_mem::Ptr{Void},nfQSevals::Ptr{Clong},nQSetfails::Ptr{Clong})
+    ccall((:CVodeGetQuadSensStats,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,nfQSevals,nQSetfails)
+end
+
+function CVodeAdjInit(cvode_mem::Ptr{Void},steps::Int,interp::Int)
+    ccall((:CVodeAdjInit,libsundials_cvode),Cint,(Ptr{Void},Clong,Cint),cvode_mem,steps,interp)
+end
+
+function CVodeAdjReInit(cvode_mem::Ptr{Void})
+    ccall((:CVodeAdjReInit,libsundials_cvode),Cint,(Ptr{Void},),cvode_mem)
+end
+
+function CVodeAdjFree(cvode_mem::Ptr{Void})
+    ccall((:CVodeAdjFree,libsundials_cvode),Void,(Ptr{Void},),cvode_mem)
+end
+
+function CVodeCreateB(cvode_mem::Ptr{Void},lmmB::Int,iterB::Int,which::Ptr{Cint})
+    ccall((:CVodeCreateB,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint,Ptr{Cint}),cvode_mem,lmmB,iterB,which)
+end
+
+function CVodeInitB(cvode_mem::Ptr{Void},which::Int,fB::CVRhsFnB,tB0::realtype,yB0::N_Vector)
+    ccall((:CVodeInitB,libsundials_cvode),Cint,(Ptr{Void},Cint,CVRhsFnB,realtype,N_Vector),cvode_mem,which,fB,tB0,yB0)
+end
+
+function CVodeInitBS(cvode_mem::Ptr{Void},which::Int,fBs::CVRhsFnBS,tB0::realtype,yB0::N_Vector)
+    ccall((:CVodeInitBS,libsundials_cvode),Cint,(Ptr{Void},Cint,CVRhsFnBS,realtype,N_Vector),cvode_mem,which,fBs,tB0,yB0)
+end
+
+function CVodeReInitB(cvode_mem::Ptr{Void},which::Int,tB0::realtype,yB0::N_Vector)
+    ccall((:CVodeReInitB,libsundials_cvode),Cint,(Ptr{Void},Cint,realtype,N_Vector),cvode_mem,which,tB0,yB0)
+end
+
+function CVodeSStolerancesB(cvode_mem::Ptr{Void},which::Int,reltolB::realtype,abstolB::realtype)
+    ccall((:CVodeSStolerancesB,libsundials_cvode),Cint,(Ptr{Void},Cint,realtype,realtype),cvode_mem,which,reltolB,abstolB)
+end
+
+function CVodeSVtolerancesB(cvode_mem::Ptr{Void},which::Int,reltolB::realtype,abstolB::N_Vector)
+    ccall((:CVodeSVtolerancesB,libsundials_cvode),Cint,(Ptr{Void},Cint,realtype,N_Vector),cvode_mem,which,reltolB,abstolB)
+end
+
+function CVodeQuadInitB(cvode_mem::Ptr{Void},which::Int,fQB::CVQuadRhsFnB,yQB0::N_Vector)
+    ccall((:CVodeQuadInitB,libsundials_cvode),Cint,(Ptr{Void},Cint,CVQuadRhsFnB,N_Vector),cvode_mem,which,fQB,yQB0)
+end
+
+function CVodeQuadInitBS(cvode_mem::Ptr{Void},which::Int,fQBs::CVQuadRhsFnBS,yQB0::N_Vector)
+    ccall((:CVodeQuadInitBS,libsundials_cvode),Cint,(Ptr{Void},Cint,CVQuadRhsFnBS,N_Vector),cvode_mem,which,fQBs,yQB0)
+end
+
+function CVodeQuadReInitB(cvode_mem::Ptr{Void},which::Int,yQB0::N_Vector)
+    ccall((:CVodeQuadReInitB,libsundials_cvode),Cint,(Ptr{Void},Cint,N_Vector),cvode_mem,which,yQB0)
+end
+
+function CVodeQuadSStolerancesB(cvode_mem::Ptr{Void},which::Int,reltolQB::realtype,abstolQB::realtype)
+    ccall((:CVodeQuadSStolerancesB,libsundials_cvode),Cint,(Ptr{Void},Cint,realtype,realtype),cvode_mem,which,reltolQB,abstolQB)
+end
+
+function CVodeQuadSVtolerancesB(cvode_mem::Ptr{Void},which::Int,reltolQB::realtype,abstolQB::N_Vector)
+    ccall((:CVodeQuadSVtolerancesB,libsundials_cvode),Cint,(Ptr{Void},Cint,realtype,N_Vector),cvode_mem,which,reltolQB,abstolQB)
+end
+
+function CVodeF(cvode_mem::Ptr{Void},tout::realtype,yout::N_Vector,tret::Vector{realtype},itask::Int,ncheckPtr::Ptr{Cint})
+    ccall((:CVodeF,libsundials_cvode),Cint,(Ptr{Void},realtype,N_Vector,Ptr{realtype},Cint,Ptr{Cint}),cvode_mem,tout,yout,tret,itask,ncheckPtr)
+end
+
+function CVodeB(cvode_mem::Ptr{Void},tBout::realtype,itaskB::Int)
+    ccall((:CVodeB,libsundials_cvode),Cint,(Ptr{Void},realtype,Cint),cvode_mem,tBout,itaskB)
+end
+
+function CVodeSetAdjNoSensi(cvode_mem::Ptr{Void})
+    ccall((:CVodeSetAdjNoSensi,libsundials_cvode),Cint,(Ptr{Void},),cvode_mem)
+end
+
+function CVodeSetIterTypeB(cvode_mem::Ptr{Void},which::Int,iterB::Int)
+    ccall((:CVodeSetIterTypeB,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint),cvode_mem,which,iterB)
+end
+
+function CVodeSetUserDataB(cvode_mem::Ptr{Void},which::Int,user_dataB::Ptr{Void})
+    ccall((:CVodeSetUserDataB,libsundials_cvode),Cint,(Ptr{Void},Cint,Ptr{Void}),cvode_mem,which,user_dataB)
+end
+
+function CVodeSetMaxOrdB(cvode_mem::Ptr{Void},which::Int,maxordB::Int)
+    ccall((:CVodeSetMaxOrdB,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint),cvode_mem,which,maxordB)
+end
+
+function CVodeSetMaxNumStepsB(cvode_mem::Ptr{Void},which::Int,mxstepsB::Int)
+    ccall((:CVodeSetMaxNumStepsB,libsundials_cvode),Cint,(Ptr{Void},Cint,Clong),cvode_mem,which,mxstepsB)
+end
+
+function CVodeSetStabLimDetB(cvode_mem::Ptr{Void},which::Int,stldetB::Int)
+    ccall((:CVodeSetStabLimDetB,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint),cvode_mem,which,stldetB)
+end
+
+function CVodeSetInitStepB(cvode_mem::Ptr{Void},which::Int,hinB::realtype)
+    ccall((:CVodeSetInitStepB,libsundials_cvode),Cint,(Ptr{Void},Cint,realtype),cvode_mem,which,hinB)
+end
+
+function CVodeSetMinStepB(cvode_mem::Ptr{Void},which::Int,hminB::realtype)
+    ccall((:CVodeSetMinStepB,libsundials_cvode),Cint,(Ptr{Void},Cint,realtype),cvode_mem,which,hminB)
+end
+
+function CVodeSetMaxStepB(cvode_mem::Ptr{Void},which::Int,hmaxB::realtype)
+    ccall((:CVodeSetMaxStepB,libsundials_cvode),Cint,(Ptr{Void},Cint,realtype),cvode_mem,which,hmaxB)
+end
+
+function CVodeSetQuadErrConB(cvode_mem::Ptr{Void},which::Int,errconQB::Int)
+    ccall((:CVodeSetQuadErrConB,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint),cvode_mem,which,errconQB)
+end
+
+function CVodeGetB(cvode_mem::Ptr{Void},which::Int,tBret::Vector{realtype},yB::N_Vector)
+    ccall((:CVodeGetB,libsundials_cvode),Cint,(Ptr{Void},Cint,Ptr{realtype},N_Vector),cvode_mem,which,tBret,yB)
+end
+
+function CVodeGetQuadB(cvode_mem::Ptr{Void},which::Int,tBret::Vector{realtype},qB::N_Vector)
+    ccall((:CVodeGetQuadB,libsundials_cvode),Cint,(Ptr{Void},Cint,Ptr{realtype},N_Vector),cvode_mem,which,tBret,qB)
+end
+
+function CVodeGetAdjCVodeBmem(cvode_mem::Ptr{Void},which::Int)
+    ccall((:CVodeGetAdjCVodeBmem,libsundials_cvode),Ptr{Void},(Ptr{Void},Cint),cvode_mem,which)
+end
+
+function CVodeGetAdjY(cvode_mem::Ptr{Void},t::realtype,y::N_Vector)
+    ccall((:CVodeGetAdjY,libsundials_cvode),Cint,(Ptr{Void},realtype,N_Vector),cvode_mem,t,y)
+end
+
+function CVodeGetAdjCheckPointsInfo(cvode_mem::Ptr{Void},ckpnt::Ptr{CVadjCheckPointRec})
+    ccall((:CVodeGetAdjCheckPointsInfo,libsundials_cvode),Cint,(Ptr{Void},Ptr{CVadjCheckPointRec}),cvode_mem,ckpnt)
+end
+
+function CVodeGetAdjDataPointHermite(cvode_mem::Ptr{Void},which::Int,t::Vector{realtype},y::N_Vector,yd::N_Vector)
+    ccall((:CVodeGetAdjDataPointHermite,libsundials_cvode),Cint,(Ptr{Void},Cint,Ptr{realtype},N_Vector,N_Vector),cvode_mem,which,t,y,yd)
+end
+
+function CVodeGetAdjDataPointPolynomial(cvode_mem::Ptr{Void},which::Int,t::Vector{realtype},order::Ptr{Cint},y::N_Vector)
+    ccall((:CVodeGetAdjDataPointPolynomial,libsundials_cvode),Cint,(Ptr{Void},Cint,Ptr{realtype},Ptr{Cint},N_Vector),cvode_mem,which,t,order,y)
+end
+
+function CVodeGetAdjCurrentCheckPoint(cvode_mem::Ptr{Void},addr::Vector{Ptr{Void}})
+    ccall((:CVodeGetAdjCurrentCheckPoint,libsundials_cvode),Cint,(Ptr{Void},Ptr{Ptr{Void}}),cvode_mem,addr)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvodes/cvodes_direct.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+
+function CVDlsSetDenseJacFn(cvode_mem::Ptr{Void},jac::CVDlsDenseJacFn)
+    ccall((:CVDlsSetDenseJacFn,libsundials_cvode),Cint,(Ptr{Void},CVDlsDenseJacFn),cvode_mem,jac)
+end
+
+function CVDlsSetBandJacFn(cvode_mem::Ptr{Void},jac::CVDlsBandJacFn)
+    ccall((:CVDlsSetBandJacFn,libsundials_cvode),Cint,(Ptr{Void},CVDlsBandJacFn),cvode_mem,jac)
+end
+
+function CVDlsGetWorkSpace(cvode_mem::Ptr{Void},lenrwLS::Ptr{Clong},leniwLS::Ptr{Clong})
+    ccall((:CVDlsGetWorkSpace,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,lenrwLS,leniwLS)
+end
+
+function CVDlsGetNumJacEvals(cvode_mem::Ptr{Void},njevals::Ptr{Clong})
+    ccall((:CVDlsGetNumJacEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,njevals)
+end
+
+function CVDlsGetNumRhsEvals(cvode_mem::Ptr{Void},nfevalsLS::Ptr{Clong})
+    ccall((:CVDlsGetNumRhsEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nfevalsLS)
+end
+
+function CVDlsGetLastFlag(cvode_mem::Ptr{Void},flag::Ptr{Clong})
+    ccall((:CVDlsGetLastFlag,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,flag)
+end
+
+function CVDlsGetReturnFlagName(flag::Int)
+    ccall((:CVDlsGetReturnFlagName,libsundials_cvode),Ptr{UInt8},(Clong,),flag)
+end
+
+function CVDlsSetDenseJacFnB(cvode_mem::Ptr{Void},which::Int,jacB::CVDlsDenseJacFnB)
+    ccall((:CVDlsSetDenseJacFnB,libsundials_cvode),Cint,(Ptr{Void},Cint,CVDlsDenseJacFnB),cvode_mem,which,jacB)
+end
+
+function CVDlsSetBandJacFnB(cvode_mem::Ptr{Void},which::Int,jacB::CVDlsBandJacFnB)
+    ccall((:CVDlsSetBandJacFnB,libsundials_cvode),Cint,(Ptr{Void},Cint,CVDlsBandJacFnB),cvode_mem,which,jacB)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvodes/cvodes_spils.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function CVSpilsSetPrecType(cvode_mem::Ptr{Void},pretype::Int)
+    ccall((:CVSpilsSetPrecType,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,pretype)
+end
+
+function CVSpilsSetGSType(cvode_mem::Ptr{Void},gstype::Int)
+    ccall((:CVSpilsSetGSType,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,gstype)
+end
+
+function CVSpilsSetMaxl(cvode_mem::Ptr{Void},maxl::Int)
+    ccall((:CVSpilsSetMaxl,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,maxl)
+end
+
+function CVSpilsSetEpsLin(cvode_mem::Ptr{Void},eplifac::realtype)
+    ccall((:CVSpilsSetEpsLin,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,eplifac)
+end
+
+function CVSpilsSetPreconditioner(cvode_mem::Ptr{Void},pset::CVSpilsPrecSetupFn,psolve::CVSpilsPrecSolveFn)
+    ccall((:CVSpilsSetPreconditioner,libsundials_cvode),Cint,(Ptr{Void},CVSpilsPrecSetupFn,CVSpilsPrecSolveFn),cvode_mem,pset,psolve)
+end
+
+function CVSpilsSetJacTimesVecFn(cvode_mem::Ptr{Void},jtv::CVSpilsJacTimesVecFn)
+    ccall((:CVSpilsSetJacTimesVecFn,libsundials_cvode),Cint,(Ptr{Void},CVSpilsJacTimesVecFn),cvode_mem,jtv)
+end
+
+function CVSpilsGetWorkSpace(cvode_mem::Ptr{Void},lenrwLS::Ptr{Clong},leniwLS::Ptr{Clong})
+    ccall((:CVSpilsGetWorkSpace,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,lenrwLS,leniwLS)
+end
+
+function CVSpilsGetNumPrecEvals(cvode_mem::Ptr{Void},npevals::Ptr{Clong})
+    ccall((:CVSpilsGetNumPrecEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,npevals)
+end
+
+function CVSpilsGetNumPrecSolves(cvode_mem::Ptr{Void},npsolves::Ptr{Clong})
+    ccall((:CVSpilsGetNumPrecSolves,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,npsolves)
+end
+
+function CVSpilsGetNumLinIters(cvode_mem::Ptr{Void},nliters::Ptr{Clong})
+    ccall((:CVSpilsGetNumLinIters,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nliters)
+end
+
+function CVSpilsGetNumConvFails(cvode_mem::Ptr{Void},nlcfails::Ptr{Clong})
+    ccall((:CVSpilsGetNumConvFails,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nlcfails)
+end
+
+function CVSpilsGetNumJtimesEvals(cvode_mem::Ptr{Void},njvevals::Ptr{Clong})
+    ccall((:CVSpilsGetNumJtimesEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,njvevals)
+end
+
+function CVSpilsGetNumRhsEvals(cvode_mem::Ptr{Void},nfevalsLS::Ptr{Clong})
+    ccall((:CVSpilsGetNumRhsEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nfevalsLS)
+end
+
+function CVSpilsGetLastFlag(cvode_mem::Ptr{Void},flag::Ptr{Clong})
+    ccall((:CVSpilsGetLastFlag,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,flag)
+end
+
+function CVSpilsGetReturnFlagName(flag::Int)
+    ccall((:CVSpilsGetReturnFlagName,libsundials_cvode),Ptr{UInt8},(Clong,),flag)
+end
+
+function CVSpilsSetPrecTypeB(cvode_mem::Ptr{Void},which::Int,pretypeB::Int)
+    ccall((:CVSpilsSetPrecTypeB,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint),cvode_mem,which,pretypeB)
+end
+
+function CVSpilsSetGSTypeB(cvode_mem::Ptr{Void},which::Int,gstypeB::Int)
+    ccall((:CVSpilsSetGSTypeB,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint),cvode_mem,which,gstypeB)
+end
+
+function CVSpilsSetEpslinB(cvode_mem::Ptr{Void},which::Int,eplifacB::realtype)
+    ccall((:CVSpilsSetEpslinB,libsundials_cvode),Cint,(Ptr{Void},Cint,realtype),cvode_mem,which,eplifacB)
+end
+
+function CVSpilsSetMaxlB(cvode_mem::Ptr{Void},which::Int,maxlB::Int)
+    ccall((:CVSpilsSetMaxlB,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint),cvode_mem,which,maxlB)
+end
+
+function CVSpilsSetPreconditionerB(cvode_mem::Ptr{Void},which::Int,psetB::CVSpilsPrecSetupFnB,psolveB::CVSpilsPrecSolveFnB)
+    ccall((:CVSpilsSetPreconditionerB,libsundials_cvode),Cint,(Ptr{Void},Cint,CVSpilsPrecSetupFnB,CVSpilsPrecSolveFnB),cvode_mem,which,psetB,psolveB)
+end
+
+function CVSpilsSetJacTimesVecFnB(cvode_mem::Ptr{Void},which::Int,jtvB::CVSpilsJacTimesVecFnB)
+    ccall((:CVSpilsSetJacTimesVecFnB,libsundials_cvode),Cint,(Ptr{Void},Cint,CVSpilsJacTimesVecFnB),cvode_mem,which,jtvB)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvodes/cvodes_band.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function CVBand(cvode_mem::Ptr{Void},N::Int,mupper::Int,mlower::Int)
+    ccall((:CVBand,libsundials_cvode),Cint,(Ptr{Void},Clong,Clong,Clong),cvode_mem,N,mupper,mlower)
+end
+
+function CVBandB(cvode_mem::Ptr{Void},which::Int,nB::Int,mupperB::Int,mlowerB::Int)
+    ccall((:CVBandB,libsundials_cvode),Cint,(Ptr{Void},Cint,Clong,Clong,Clong),cvode_mem,which,nB,mupperB,mlowerB)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvodes/cvodes_bandpre.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function CVBandPrecInit(cvode_mem::Ptr{Void},N::Int,mu::Int,ml::Int)
+    ccall((:CVBandPrecInit,libsundials_cvode),Cint,(Ptr{Void},Clong,Clong,Clong),cvode_mem,N,mu,ml)
+end
+
+function CVBandPrecGetWorkSpace(cvode_mem::Ptr{Void},lenrwLS::Ptr{Clong},leniwLS::Ptr{Clong})
+    ccall((:CVBandPrecGetWorkSpace,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,lenrwLS,leniwLS)
+end
+
+function CVBandPrecGetNumRhsEvals(cvode_mem::Ptr{Void},nfevalsBP::Ptr{Clong})
+    ccall((:CVBandPrecGetNumRhsEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nfevalsBP)
+end
+
+function CVBandPrecInitB(cvode_mem::Ptr{Void},which::Int,nB::Int,muB::Int,mlB::Int)
+    ccall((:CVBandPrecInitB,libsundials_cvode),Cint,(Ptr{Void},Cint,Clong,Clong,Clong),cvode_mem,which,nB,muB,mlB)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvodes/cvodes_bbdpre.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function CVBBDPrecInit(cvode_mem::Ptr{Void},Nlocal::Int,mudq::Int,mldq::Int,mukeep::Int,mlkeep::Int,dqrely::realtype,gloc::CVLocalFn,cfn::CVCommFn)
+    ccall((:CVBBDPrecInit,libsundials_cvode),Cint,(Ptr{Void},Clong,Clong,Clong,Clong,Clong,realtype,CVLocalFn,CVCommFn),cvode_mem,Nlocal,mudq,mldq,mukeep,mlkeep,dqrely,gloc,cfn)
+end
+
+function CVBBDPrecReInit(cvode_mem::Ptr{Void},mudq::Int,mldq::Int,dqrely::realtype)
+    ccall((:CVBBDPrecReInit,libsundials_cvode),Cint,(Ptr{Void},Clong,Clong,realtype),cvode_mem,mudq,mldq,dqrely)
+end
+
+function CVBBDPrecGetWorkSpace(cvode_mem::Ptr{Void},lenrwBBDP::Ptr{Clong},leniwBBDP::Ptr{Clong})
+    ccall((:CVBBDPrecGetWorkSpace,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,lenrwBBDP,leniwBBDP)
+end
+
+function CVBBDPrecGetNumGfnEvals(cvode_mem::Ptr{Void},ngevalsBBDP::Ptr{Clong})
+    ccall((:CVBBDPrecGetNumGfnEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,ngevalsBBDP)
+end
+
+function CVBBDPrecInitB(cvode_mem::Ptr{Void},which::Int,NlocalB::Int,mudqB::Int,mldqB::Int,mukeepB::Int,mlkeepB::Int,dqrelyB::realtype,glocB::CVLocalFnB,cfnB::CVCommFnB)
+    ccall((:CVBBDPrecInitB,libsundials_cvode),Cint,(Ptr{Void},Cint,Clong,Clong,Clong,Clong,Clong,realtype,CVLocalFnB,CVCommFnB),cvode_mem,which,NlocalB,mudqB,mldqB,mukeepB,mlkeepB,dqrelyB,glocB,cfnB)
+end
+
+function CVBBDPrecReInitB(cvode_mem::Ptr{Void},which::Int,mudqB::Int,mldqB::Int,dqrelyB::realtype)
+    ccall((:CVBBDPrecReInitB,libsundials_cvode),Cint,(Ptr{Void},Cint,Clong,Clong,realtype),cvode_mem,which,mudqB,mldqB,dqrelyB)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvodes/cvodes_dense.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function CVDense(cvode_mem::Ptr{Void},N::Int)
+    ccall((:CVDense,libsundials_cvode),Cint,(Ptr{Void},Clong),cvode_mem,N)
+end
+
+function CVDenseB(cvode_mem::Ptr{Void},which::Int,nB::Int)
+    ccall((:CVDenseB,libsundials_cvode),Cint,(Ptr{Void},Cint,Clong),cvode_mem,which,nB)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvodes/cvodes_diag.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function CVDiag(cvode_mem::Ptr{Void})
+    ccall((:CVDiag,libsundials_cvode),Cint,(Ptr{Void},),cvode_mem)
+end
+
+function CVDiagGetWorkSpace(cvode_mem::Ptr{Void},lenrwLS::Ptr{Clong},leniwLS::Ptr{Clong})
+    ccall((:CVDiagGetWorkSpace,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,lenrwLS,leniwLS)
+end
+
+function CVDiagGetNumRhsEvals(cvode_mem::Ptr{Void},nfevalsLS::Ptr{Clong})
+    ccall((:CVDiagGetNumRhsEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nfevalsLS)
+end
+
+function CVDiagGetLastFlag(cvode_mem::Ptr{Void},flag::Ptr{Clong})
+    ccall((:CVDiagGetLastFlag,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,flag)
+end
+
+function CVDiagGetReturnFlagName(flag::Int)
+    ccall((:CVDiagGetReturnFlagName,libsundials_cvode),Ptr{UInt8},(Clong,),flag)
+end
+
+function CVDiagB(cvode_mem::Ptr{Void},which::Int)
+    ccall((:CVDiagB,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,which)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvodes/cvodes_impl.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function CVodeSStolerances(cvode_mem::Ptr{Void},reltol::realtype,abstol::realtype)
+    ccall((:CVodeSStolerances,libsundials_cvode),Cint,(Ptr{Void},realtype,realtype),cvode_mem,reltol,abstol)
+end
+
+function CVodeSVtolerances(cvode_mem::Ptr{Void},reltol::realtype,abstol::N_Vector)
+    ccall((:CVodeSVtolerances,libsundials_cvode),Cint,(Ptr{Void},realtype,N_Vector),cvode_mem,reltol,abstol)
+end
+
+function CVodeWFtolerances(cvode_mem::Ptr{Void},efun::CVEwtFn)
+    ccall((:CVodeWFtolerances,libsundials_cvode),Cint,(Ptr{Void},CVEwtFn),cvode_mem,efun)
+end
+
+function CVodeQuadInit(cvode_mem::Ptr{Void},fQ::CVQuadRhsFn,yQ0::N_Vector)
+    ccall((:CVodeQuadInit,libsundials_cvode),Cint,(Ptr{Void},CVQuadRhsFn,N_Vector),cvode_mem,fQ,yQ0)
+end
+
+function CVodeQuadReInit(cvode_mem::Ptr{Void},yQ0::N_Vector)
+    ccall((:CVodeQuadReInit,libsundials_cvode),Cint,(Ptr{Void},N_Vector),cvode_mem,yQ0)
+end
+
+function CVodeQuadSStolerances(cvode_mem::Ptr{Void},reltolQ::realtype,abstolQ::realtype)
+    ccall((:CVodeQuadSStolerances,libsundials_cvode),Cint,(Ptr{Void},realtype,realtype),cvode_mem,reltolQ,abstolQ)
+end
+
+function CVodeQuadSVtolerances(cvode_mem::Ptr{Void},reltolQ::realtype,abstolQ::N_Vector)
+    ccall((:CVodeQuadSVtolerances,libsundials_cvode),Cint,(Ptr{Void},realtype,N_Vector),cvode_mem,reltolQ,abstolQ)
+end
+
+function CVodeSensInit(cvode_mem::Ptr{Void},Ns::Int,ism::Int,fS::CVSensRhsFn,yS0::Ptr{N_Vector})
+    ccall((:CVodeSensInit,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint,CVSensRhsFn,Ptr{N_Vector}),cvode_mem,Ns,ism,fS,yS0)
+end
+
+function CVodeSensInit1(cvode_mem::Ptr{Void},Ns::Int,ism::Int,fS1::CVSensRhs1Fn,yS0::Ptr{N_Vector})
+    ccall((:CVodeSensInit1,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint,CVSensRhs1Fn,Ptr{N_Vector}),cvode_mem,Ns,ism,fS1,yS0)
+end
+
+function CVodeSensReInit(cvode_mem::Ptr{Void},ism::Int,yS0::Ptr{N_Vector})
+    ccall((:CVodeSensReInit,libsundials_cvode),Cint,(Ptr{Void},Cint,Ptr{N_Vector}),cvode_mem,ism,yS0)
+end
+
+function CVodeSensSStolerances(cvode_mem::Ptr{Void},reltolS::realtype,abstolS::Vector{realtype})
+    ccall((:CVodeSensSStolerances,libsundials_cvode),Cint,(Ptr{Void},realtype,Ptr{realtype}),cvode_mem,reltolS,abstolS)
+end
+
+function CVodeSensSVtolerances(cvode_mem::Ptr{Void},reltolS::realtype,abstolS::Ptr{N_Vector})
+    ccall((:CVodeSensSVtolerances,libsundials_cvode),Cint,(Ptr{Void},realtype,Ptr{N_Vector}),cvode_mem,reltolS,abstolS)
+end
+
+function CVodeSensEEtolerances(cvode_mem::Ptr{Void})
+    ccall((:CVodeSensEEtolerances,libsundials_cvode),Cint,(Ptr{Void},),cvode_mem)
+end
+
+function CVodeQuadSensInit(cvode_mem::Ptr{Void},fQS::CVQuadSensRhsFn,yQS0::Ptr{N_Vector})
+    ccall((:CVodeQuadSensInit,libsundials_cvode),Cint,(Ptr{Void},CVQuadSensRhsFn,Ptr{N_Vector}),cvode_mem,fQS,yQS0)
+end
+
+function CVodeQuadSensReInit(cvode_mem::Ptr{Void},yQS0::Ptr{N_Vector})
+    ccall((:CVodeQuadSensReInit,libsundials_cvode),Cint,(Ptr{Void},Ptr{N_Vector}),cvode_mem,yQS0)
+end
+
+function CVodeQuadSensSStolerances(cvode_mem::Ptr{Void},reltolQS::realtype,abstolQS::Vector{realtype})
+    ccall((:CVodeQuadSensSStolerances,libsundials_cvode),Cint,(Ptr{Void},realtype,Ptr{realtype}),cvode_mem,reltolQS,abstolQS)
+end
+
+function CVodeQuadSensSVtolerances(cvode_mem::Ptr{Void},reltolQS::realtype,abstolQS::Ptr{N_Vector})
+    ccall((:CVodeQuadSensSVtolerances,libsundials_cvode),Cint,(Ptr{Void},realtype,Ptr{N_Vector}),cvode_mem,reltolQS,abstolQS)
+end
+
+function CVodeQuadSensEEtolerances(cvode_mem::Ptr{Void})
+    ccall((:CVodeQuadSensEEtolerances,libsundials_cvode),Cint,(Ptr{Void},),cvode_mem)
+end
+
+function CVodeRootInit(cvode_mem::Ptr{Void},nrtfn::Int,g::CVRootFn)
+    ccall((:CVodeRootInit,libsundials_cvode),Cint,(Ptr{Void},Cint,CVRootFn),cvode_mem,nrtfn,g)
+end
+
+function CVodeFree(cvode_mem::Vector{Ptr{Void}})
+    ccall((:CVodeFree,libsundials_cvode),Void,(Ptr{Ptr{Void}},),cvode_mem)
+end
+
+function CVodeQuadFree(cvode_mem::Ptr{Void})
+    ccall((:CVodeQuadFree,libsundials_cvode),Void,(Ptr{Void},),cvode_mem)
+end
+
+function CVodeSensFree(cvode_mem::Ptr{Void})
+    ccall((:CVodeSensFree,libsundials_cvode),Void,(Ptr{Void},),cvode_mem)
+end
+
+function CVodeQuadSensFree(cvode_mem::Ptr{Void})
+    ccall((:CVodeQuadSensFree,libsundials_cvode),Void,(Ptr{Void},),cvode_mem)
+end
+
+function CVodeSetErrHandlerFn(cvode_mem::Ptr{Void},ehfun::CVErrHandlerFn,eh_data::Ptr{Void})
+    ccall((:CVodeSetErrHandlerFn,libsundials_cvode),Cint,(Ptr{Void},CVErrHandlerFn,Ptr{Void}),cvode_mem,ehfun,eh_data)
+end
+
+function CVodeSetErrFile(cvode_mem::Ptr{Void},errfp::Ptr{Void})
+    ccall((:CVodeSetErrFile,libsundials_cvode),Cint,(Ptr{Void},Ptr{Void}),cvode_mem,errfp)
+end
+
+function CVodeSetUserData(cvode_mem::Ptr{Void},user_data::Ptr{Void})
+    ccall((:CVodeSetUserData,libsundials_cvode),Cint,(Ptr{Void},Ptr{Void}),cvode_mem,user_data)
+end
+
+function CVodeSetMaxOrd(cvode_mem::Ptr{Void},maxord::Int)
+    ccall((:CVodeSetMaxOrd,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,maxord)
+end
+
+function CVodeSetMaxNumSteps(cvode_mem::Ptr{Void},mxsteps::Int)
+    ccall((:CVodeSetMaxNumSteps,libsundials_cvode),Cint,(Ptr{Void},Clong),cvode_mem,mxsteps)
+end
+
+function CVodeSetMaxHnilWarns(cvode_mem::Ptr{Void},mxhnil::Int)
+    ccall((:CVodeSetMaxHnilWarns,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,mxhnil)
+end
+
+function CVodeSetStabLimDet(cvode_mem::Ptr{Void},stldet::Int)
+    ccall((:CVodeSetStabLimDet,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,stldet)
+end
+
+function CVodeSetInitStep(cvode_mem::Ptr{Void},hin::realtype)
+    ccall((:CVodeSetInitStep,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,hin)
+end
+
+function CVodeSetMinStep(cvode_mem::Ptr{Void},hmin::realtype)
+    ccall((:CVodeSetMinStep,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,hmin)
+end
+
+function CVodeSetMaxStep(cvode_mem::Ptr{Void},hmax::realtype)
+    ccall((:CVodeSetMaxStep,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,hmax)
+end
+
+function CVodeSetStopTime(cvode_mem::Ptr{Void},tstop::realtype)
+    ccall((:CVodeSetStopTime,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,tstop)
+end
+
+function CVodeSetMaxErrTestFails(cvode_mem::Ptr{Void},maxnef::Int)
+    ccall((:CVodeSetMaxErrTestFails,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,maxnef)
+end
+
+function CVodeSetMaxNonlinIters(cvode_mem::Ptr{Void},maxcor::Int)
+    ccall((:CVodeSetMaxNonlinIters,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,maxcor)
+end
+
+function CVodeSetMaxConvFails(cvode_mem::Ptr{Void},maxncf::Int)
+    ccall((:CVodeSetMaxConvFails,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,maxncf)
+end
+
+function CVodeSetNonlinConvCoef(cvode_mem::Ptr{Void},nlscoef::realtype)
+    ccall((:CVodeSetNonlinConvCoef,libsundials_cvode),Cint,(Ptr{Void},realtype),cvode_mem,nlscoef)
+end
+
+function CVodeSetIterType(cvode_mem::Ptr{Void},iter::Int)
+    ccall((:CVodeSetIterType,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,iter)
+end
+
+function CVodeSetRootDirection(cvode_mem::Ptr{Void},rootdir::Ptr{Cint})
+    ccall((:CVodeSetRootDirection,libsundials_cvode),Cint,(Ptr{Void},Ptr{Cint}),cvode_mem,rootdir)
+end
+
+function CVodeSetNoInactiveRootWarn(cvode_mem::Ptr{Void})
+    ccall((:CVodeSetNoInactiveRootWarn,libsundials_cvode),Cint,(Ptr{Void},),cvode_mem)
+end
+
+function CVodeSetQuadErrCon(cvode_mem::Ptr{Void},errconQ::Int)
+    ccall((:CVodeSetQuadErrCon,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,errconQ)
+end
+
+function CVodeSetSensDQMethod(cvode_mem::Ptr{Void},DQtype::Int,DQrhomax::realtype)
+    ccall((:CVodeSetSensDQMethod,libsundials_cvode),Cint,(Ptr{Void},Cint,realtype),cvode_mem,DQtype,DQrhomax)
+end
+
+function CVodeSetSensErrCon(cvode_mem::Ptr{Void},errconS::Int)
+    ccall((:CVodeSetSensErrCon,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,errconS)
+end
+
+function CVodeSetSensMaxNonlinIters(cvode_mem::Ptr{Void},maxcorS::Int)
+    ccall((:CVodeSetSensMaxNonlinIters,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,maxcorS)
+end
+
+function CVodeSetSensParams(cvode_mem::Ptr{Void},p::Vector{realtype},pbar::Vector{realtype},plist::Ptr{Cint})
+    ccall((:CVodeSetSensParams,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype},Ptr{realtype},Ptr{Cint}),cvode_mem,p,pbar,plist)
+end
+
+function CVodeSetQuadSensErrCon(cvode_mem::Ptr{Void},errconQS::Int)
+    ccall((:CVodeSetQuadSensErrCon,libsundials_cvode),Cint,(Ptr{Void},Cint),cvode_mem,errconQS)
+end
+
+function CVodeSensToggleOff(cvode_mem::Ptr{Void})
+    ccall((:CVodeSensToggleOff,libsundials_cvode),Cint,(Ptr{Void},),cvode_mem)
+end
+
+function CVode(cvode_mem::Ptr{Void},tout::realtype,yout::N_Vector,tret::Vector{realtype},itask::Int)
+    ccall((:CVode,libsundials_cvode),Cint,(Ptr{Void},realtype,N_Vector,Ptr{realtype},Cint),cvode_mem,tout,yout,tret,itask)
+end
+
+function CVodeGetDky(cvode_mem::Ptr{Void},t::realtype,k::Int,dky::N_Vector)
+    ccall((:CVodeGetDky,libsundials_cvode),Cint,(Ptr{Void},realtype,Cint,N_Vector),cvode_mem,t,k,dky)
+end
+
+function CVodeGetQuad(cvode_mem::Ptr{Void},tret::Vector{realtype},yQout::N_Vector)
+    ccall((:CVodeGetQuad,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype},N_Vector),cvode_mem,tret,yQout)
+end
+
+function CVodeGetQuadDky(cvode_mem::Ptr{Void},t::realtype,k::Int,dky::N_Vector)
+    ccall((:CVodeGetQuadDky,libsundials_cvode),Cint,(Ptr{Void},realtype,Cint,N_Vector),cvode_mem,t,k,dky)
+end
+
+function CVodeGetSens(cvode_mem::Ptr{Void},tret::Vector{realtype},ySout::Ptr{N_Vector})
+    ccall((:CVodeGetSens,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype},Ptr{N_Vector}),cvode_mem,tret,ySout)
+end
+
+function CVodeGetSens1(cvode_mem::Ptr{Void},tret::Vector{realtype},is::Int,ySout::N_Vector)
+    ccall((:CVodeGetSens1,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype},Cint,N_Vector),cvode_mem,tret,is,ySout)
+end
+
+function CVodeGetSensDky(cvode_mem::Ptr{Void},t::realtype,k::Int,dkyA::Ptr{N_Vector})
+    ccall((:CVodeGetSensDky,libsundials_cvode),Cint,(Ptr{Void},realtype,Cint,Ptr{N_Vector}),cvode_mem,t,k,dkyA)
+end
+
+function CVodeGetSensDky1(cvode_mem::Ptr{Void},t::realtype,k::Int,is::Int,dky::N_Vector)
+    ccall((:CVodeGetSensDky1,libsundials_cvode),Cint,(Ptr{Void},realtype,Cint,Cint,N_Vector),cvode_mem,t,k,is,dky)
+end
+
+function CVodeGetQuadSens(cvode_mem::Ptr{Void},tret::Vector{realtype},yQSout::Ptr{N_Vector})
+    ccall((:CVodeGetQuadSens,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype},Ptr{N_Vector}),cvode_mem,tret,yQSout)
+end
+
+function CVodeGetQuadSens1(cvode_mem::Ptr{Void},tret::Vector{realtype},is::Int,yQSout::N_Vector)
+    ccall((:CVodeGetQuadSens1,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype},Cint,N_Vector),cvode_mem,tret,is,yQSout)
+end
+
+function CVodeGetQuadSensDky(cvode_mem::Ptr{Void},t::realtype,k::Int,dkyQS_all::Ptr{N_Vector})
+    ccall((:CVodeGetQuadSensDky,libsundials_cvode),Cint,(Ptr{Void},realtype,Cint,Ptr{N_Vector}),cvode_mem,t,k,dkyQS_all)
+end
+
+function CVodeGetQuadSensDky1(cvode_mem::Ptr{Void},t::realtype,k::Int,is::Int,dkyQS::N_Vector)
+    ccall((:CVodeGetQuadSensDky1,libsundials_cvode),Cint,(Ptr{Void},realtype,Cint,Cint,N_Vector),cvode_mem,t,k,is,dkyQS)
+end
+
+function CVodeGetWorkSpace(cvode_mem::Ptr{Void},lenrw::Ptr{Clong},leniw::Ptr{Clong})
+    ccall((:CVodeGetWorkSpace,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,lenrw,leniw)
+end
+
+function CVodeGetNumSteps(cvode_mem::Ptr{Void},nsteps::Ptr{Clong})
+    ccall((:CVodeGetNumSteps,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nsteps)
+end
+
+function CVodeGetNumRhsEvals(cvode_mem::Ptr{Void},nfevals::Ptr{Clong})
+    ccall((:CVodeGetNumRhsEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nfevals)
+end
+
+function CVodeGetNumLinSolvSetups(cvode_mem::Ptr{Void},nlinsetups::Ptr{Clong})
+    ccall((:CVodeGetNumLinSolvSetups,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nlinsetups)
+end
+
+function CVodeGetNumErrTestFails(cvode_mem::Ptr{Void},netfails::Ptr{Clong})
+    ccall((:CVodeGetNumErrTestFails,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,netfails)
+end
+
+function CVodeGetLastOrder(cvode_mem::Ptr{Void},qlast::Ptr{Cint})
+    ccall((:CVodeGetLastOrder,libsundials_cvode),Cint,(Ptr{Void},Ptr{Cint}),cvode_mem,qlast)
+end
+
+function CVodeGetCurrentOrder(cvode_mem::Ptr{Void},qcur::Ptr{Cint})
+    ccall((:CVodeGetCurrentOrder,libsundials_cvode),Cint,(Ptr{Void},Ptr{Cint}),cvode_mem,qcur)
+end
+
+function CVodeGetNumStabLimOrderReds(cvode_mem::Ptr{Void},nslred::Ptr{Clong})
+    ccall((:CVodeGetNumStabLimOrderReds,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nslred)
+end
+
+function CVodeGetActualInitStep(cvode_mem::Ptr{Void},hinused::Vector{realtype})
+    ccall((:CVodeGetActualInitStep,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype}),cvode_mem,hinused)
+end
+
+function CVodeGetLastStep(cvode_mem::Ptr{Void},hlast::Vector{realtype})
+    ccall((:CVodeGetLastStep,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype}),cvode_mem,hlast)
+end
+
+function CVodeGetCurrentStep(cvode_mem::Ptr{Void},hcur::Vector{realtype})
+    ccall((:CVodeGetCurrentStep,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype}),cvode_mem,hcur)
+end
+
+function CVodeGetCurrentTime(cvode_mem::Ptr{Void},tcur::Vector{realtype})
+    ccall((:CVodeGetCurrentTime,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype}),cvode_mem,tcur)
+end
+
+function CVodeGetTolScaleFactor(cvode_mem::Ptr{Void},tolsfac::Vector{realtype})
+    ccall((:CVodeGetTolScaleFactor,libsundials_cvode),Cint,(Ptr{Void},Ptr{realtype}),cvode_mem,tolsfac)
+end
+
+function CVodeGetErrWeights(cvode_mem::Ptr{Void},eweight::N_Vector)
+    ccall((:CVodeGetErrWeights,libsundials_cvode),Cint,(Ptr{Void},N_Vector),cvode_mem,eweight)
+end
+
+function CVodeGetEstLocalErrors(cvode_mem::Ptr{Void},ele::N_Vector)
+    ccall((:CVodeGetEstLocalErrors,libsundials_cvode),Cint,(Ptr{Void},N_Vector),cvode_mem,ele)
+end
+
+function CVodeGetNumGEvals(cvode_mem::Ptr{Void},ngevals::Ptr{Clong})
+    ccall((:CVodeGetNumGEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,ngevals)
+end
+
+function CVodeGetRootInfo(cvode_mem::Ptr{Void},rootsfound::Ptr{Cint})
+    ccall((:CVodeGetRootInfo,libsundials_cvode),Cint,(Ptr{Void},Ptr{Cint}),cvode_mem,rootsfound)
+end
+
+function CVodeGetIntegratorStats(cvode_mem::Ptr{Void},nsteps::Ptr{Clong},nfevals::Ptr{Clong},nlinsetups::Ptr{Clong},netfails::Ptr{Clong},qlast::Ptr{Cint},qcur::Ptr{Cint},hinused::Vector{realtype},hlast::Vector{realtype},hcur::Vector{realtype},tcur::Vector{realtype})
+    ccall((:CVodeGetIntegratorStats,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Cint},Ptr{Cint},Ptr{realtype},Ptr{realtype},Ptr{realtype},Ptr{realtype}),cvode_mem,nsteps,nfevals,nlinsetups,netfails,qlast,qcur,hinused,hlast,hcur,tcur)
+end
+
+function CVodeGetNumNonlinSolvIters(cvode_mem::Ptr{Void},nniters::Ptr{Clong})
+    ccall((:CVodeGetNumNonlinSolvIters,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nniters)
+end
+
+function CVodeGetNumNonlinSolvConvFails(cvode_mem::Ptr{Void},nncfails::Ptr{Clong})
+    ccall((:CVodeGetNumNonlinSolvConvFails,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nncfails)
+end
+
+function CVodeGetNonlinSolvStats(cvode_mem::Ptr{Void},nniters::Ptr{Clong},nncfails::Ptr{Clong})
+    ccall((:CVodeGetNonlinSolvStats,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,nniters,nncfails)
+end
+
+function CVodeGetReturnFlagName(flag::Int)
+    ccall((:CVodeGetReturnFlagName,libsundials_cvode),Ptr{UInt8},(Clong,),flag)
+end
+
+function CVodeGetQuadNumRhsEvals(cvode_mem::Ptr{Void},nfQevals::Ptr{Clong})
+    ccall((:CVodeGetQuadNumRhsEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nfQevals)
+end
+
+function CVodeGetQuadNumErrTestFails(cvode_mem::Ptr{Void},nQetfails::Ptr{Clong})
+    ccall((:CVodeGetQuadNumErrTestFails,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nQetfails)
+end
+
+function CVodeGetQuadErrWeights(cvode_mem::Ptr{Void},eQweight::N_Vector)
+    ccall((:CVodeGetQuadErrWeights,libsundials_cvode),Cint,(Ptr{Void},N_Vector),cvode_mem,eQweight)
+end
+
+function CVodeGetQuadStats(cvode_mem::Ptr{Void},nfQevals::Ptr{Clong},nQetfails::Ptr{Clong})
+    ccall((:CVodeGetQuadStats,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,nfQevals,nQetfails)
+end
+
+function CVodeGetSensNumRhsEvals(cvode_mem::Ptr{Void},nfSevals::Ptr{Clong})
+    ccall((:CVodeGetSensNumRhsEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nfSevals)
+end
+
+function CVodeGetNumRhsEvalsSens(cvode_mem::Ptr{Void},nfevalsS::Ptr{Clong})
+    ccall((:CVodeGetNumRhsEvalsSens,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nfevalsS)
+end
+
+function CVodeGetSensNumErrTestFails(cvode_mem::Ptr{Void},nSetfails::Ptr{Clong})
+    ccall((:CVodeGetSensNumErrTestFails,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nSetfails)
+end
+
+function CVodeGetSensNumLinSolvSetups(cvode_mem::Ptr{Void},nlinsetupsS::Ptr{Clong})
+    ccall((:CVodeGetSensNumLinSolvSetups,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nlinsetupsS)
+end
+
+function CVodeGetSensErrWeights(cvode_mem::Ptr{Void},eSweight::Ptr{N_Vector})
+    ccall((:CVodeGetSensErrWeights,libsundials_cvode),Cint,(Ptr{Void},Ptr{N_Vector}),cvode_mem,eSweight)
+end
+
+function CVodeGetSensStats(cvode_mem::Ptr{Void},nfSevals::Ptr{Clong},nfevalsS::Ptr{Clong},nSetfails::Ptr{Clong},nlinsetupsS::Ptr{Clong})
+    ccall((:CVodeGetSensStats,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Clong}),cvode_mem,nfSevals,nfevalsS,nSetfails,nlinsetupsS)
+end
+
+function CVodeGetSensNumNonlinSolvIters(cvode_mem::Ptr{Void},nSniters::Ptr{Clong})
+    ccall((:CVodeGetSensNumNonlinSolvIters,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nSniters)
+end
+
+function CVodeGetSensNumNonlinSolvConvFails(cvode_mem::Ptr{Void},nSncfails::Ptr{Clong})
+    ccall((:CVodeGetSensNumNonlinSolvConvFails,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nSncfails)
+end
+
+function CVodeGetStgrSensNumNonlinSolvIters(cvode_mem::Ptr{Void},nSTGR1niters::Ptr{Clong})
+    ccall((:CVodeGetStgrSensNumNonlinSolvIters,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nSTGR1niters)
+end
+
+function CVodeGetStgrSensNumNonlinSolvConvFails(cvode_mem::Ptr{Void},nSTGR1ncfails::Ptr{Clong})
+    ccall((:CVodeGetStgrSensNumNonlinSolvConvFails,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nSTGR1ncfails)
+end
+
+function CVodeGetSensNonlinSolvStats(cvode_mem::Ptr{Void},nSniters::Ptr{Clong},nSncfails::Ptr{Clong})
+    ccall((:CVodeGetSensNonlinSolvStats,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,nSniters,nSncfails)
+end
+
+function CVodeGetQuadSensNumRhsEvals(cvode_mem::Ptr{Void},nfQSevals::Ptr{Clong})
+    ccall((:CVodeGetQuadSensNumRhsEvals,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nfQSevals)
+end
+
+function CVodeGetQuadSensNumErrTestFails(cvode_mem::Ptr{Void},nQSetfails::Ptr{Clong})
+    ccall((:CVodeGetQuadSensNumErrTestFails,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong}),cvode_mem,nQSetfails)
+end
+
+function CVodeGetQuadSensErrWeights(cvode_mem::Ptr{Void},eQSweight::Ptr{N_Vector})
+    ccall((:CVodeGetQuadSensErrWeights,libsundials_cvode),Cint,(Ptr{Void},Ptr{N_Vector}),cvode_mem,eQSweight)
+end
+
+function CVodeGetQuadSensStats(cvode_mem::Ptr{Void},nfQSevals::Ptr{Clong},nQSetfails::Ptr{Clong})
+    ccall((:CVodeGetQuadSensStats,libsundials_cvode),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),cvode_mem,nfQSevals,nQSetfails)
+end
+
+function CVodeAdjInit(cvode_mem::Ptr{Void},steps::Int,interp::Int)
+    ccall((:CVodeAdjInit,libsundials_cvode),Cint,(Ptr{Void},Clong,Cint),cvode_mem,steps,interp)
+end
+
+function CVodeAdjReInit(cvode_mem::Ptr{Void})
+    ccall((:CVodeAdjReInit,libsundials_cvode),Cint,(Ptr{Void},),cvode_mem)
+end
+
+function CVodeAdjFree(cvode_mem::Ptr{Void})
+    ccall((:CVodeAdjFree,libsundials_cvode),Void,(Ptr{Void},),cvode_mem)
+end
+
+function CVodeCreateB(cvode_mem::Ptr{Void},lmmB::Int,iterB::Int,which::Ptr{Cint})
+    ccall((:CVodeCreateB,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint,Ptr{Cint}),cvode_mem,lmmB,iterB,which)
+end
+
+function CVodeInitB(cvode_mem::Ptr{Void},which::Int,fB::CVRhsFnB,tB0::realtype,yB0::N_Vector)
+    ccall((:CVodeInitB,libsundials_cvode),Cint,(Ptr{Void},Cint,CVRhsFnB,realtype,N_Vector),cvode_mem,which,fB,tB0,yB0)
+end
+
+function CVodeInitBS(cvode_mem::Ptr{Void},which::Int,fBs::CVRhsFnBS,tB0::realtype,yB0::N_Vector)
+    ccall((:CVodeInitBS,libsundials_cvode),Cint,(Ptr{Void},Cint,CVRhsFnBS,realtype,N_Vector),cvode_mem,which,fBs,tB0,yB0)
+end
+
+function CVodeReInitB(cvode_mem::Ptr{Void},which::Int,tB0::realtype,yB0::N_Vector)
+    ccall((:CVodeReInitB,libsundials_cvode),Cint,(Ptr{Void},Cint,realtype,N_Vector),cvode_mem,which,tB0,yB0)
+end
+
+function CVodeSStolerancesB(cvode_mem::Ptr{Void},which::Int,reltolB::realtype,abstolB::realtype)
+    ccall((:CVodeSStolerancesB,libsundials_cvode),Cint,(Ptr{Void},Cint,realtype,realtype),cvode_mem,which,reltolB,abstolB)
+end
+
+function CVodeSVtolerancesB(cvode_mem::Ptr{Void},which::Int,reltolB::realtype,abstolB::N_Vector)
+    ccall((:CVodeSVtolerancesB,libsundials_cvode),Cint,(Ptr{Void},Cint,realtype,N_Vector),cvode_mem,which,reltolB,abstolB)
+end
+
+function CVodeQuadInitB(cvode_mem::Ptr{Void},which::Int,fQB::CVQuadRhsFnB,yQB0::N_Vector)
+    ccall((:CVodeQuadInitB,libsundials_cvode),Cint,(Ptr{Void},Cint,CVQuadRhsFnB,N_Vector),cvode_mem,which,fQB,yQB0)
+end
+
+function CVodeQuadInitBS(cvode_mem::Ptr{Void},which::Int,fQBs::CVQuadRhsFnBS,yQB0::N_Vector)
+    ccall((:CVodeQuadInitBS,libsundials_cvode),Cint,(Ptr{Void},Cint,CVQuadRhsFnBS,N_Vector),cvode_mem,which,fQBs,yQB0)
+end
+
+function CVodeQuadReInitB(cvode_mem::Ptr{Void},which::Int,yQB0::N_Vector)
+    ccall((:CVodeQuadReInitB,libsundials_cvode),Cint,(Ptr{Void},Cint,N_Vector),cvode_mem,which,yQB0)
+end
+
+function CVodeQuadSStolerancesB(cvode_mem::Ptr{Void},which::Int,reltolQB::realtype,abstolQB::realtype)
+    ccall((:CVodeQuadSStolerancesB,libsundials_cvode),Cint,(Ptr{Void},Cint,realtype,realtype),cvode_mem,which,reltolQB,abstolQB)
+end
+
+function CVodeQuadSVtolerancesB(cvode_mem::Ptr{Void},which::Int,reltolQB::realtype,abstolQB::N_Vector)
+    ccall((:CVodeQuadSVtolerancesB,libsundials_cvode),Cint,(Ptr{Void},Cint,realtype,N_Vector),cvode_mem,which,reltolQB,abstolQB)
+end
+
+function CVodeF(cvode_mem::Ptr{Void},tout::realtype,yout::N_Vector,tret::Vector{realtype},itask::Int,ncheckPtr::Ptr{Cint})
+    ccall((:CVodeF,libsundials_cvode),Cint,(Ptr{Void},realtype,N_Vector,Ptr{realtype},Cint,Ptr{Cint}),cvode_mem,tout,yout,tret,itask,ncheckPtr)
+end
+
+function CVodeB(cvode_mem::Ptr{Void},tBout::realtype,itaskB::Int)
+    ccall((:CVodeB,libsundials_cvode),Cint,(Ptr{Void},realtype,Cint),cvode_mem,tBout,itaskB)
+end
+
+function CVodeSetAdjNoSensi(cvode_mem::Ptr{Void})
+    ccall((:CVodeSetAdjNoSensi,libsundials_cvode),Cint,(Ptr{Void},),cvode_mem)
+end
+
+function CVodeSetIterTypeB(cvode_mem::Ptr{Void},which::Int,iterB::Int)
+    ccall((:CVodeSetIterTypeB,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint),cvode_mem,which,iterB)
+end
+
+function CVodeSetUserDataB(cvode_mem::Ptr{Void},which::Int,user_dataB::Ptr{Void})
+    ccall((:CVodeSetUserDataB,libsundials_cvode),Cint,(Ptr{Void},Cint,Ptr{Void}),cvode_mem,which,user_dataB)
+end
+
+function CVodeSetMaxOrdB(cvode_mem::Ptr{Void},which::Int,maxordB::Int)
+    ccall((:CVodeSetMaxOrdB,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint),cvode_mem,which,maxordB)
+end
+
+function CVodeSetMaxNumStepsB(cvode_mem::Ptr{Void},which::Int,mxstepsB::Int)
+    ccall((:CVodeSetMaxNumStepsB,libsundials_cvode),Cint,(Ptr{Void},Cint,Clong),cvode_mem,which,mxstepsB)
+end
+
+function CVodeSetStabLimDetB(cvode_mem::Ptr{Void},which::Int,stldetB::Int)
+    ccall((:CVodeSetStabLimDetB,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint),cvode_mem,which,stldetB)
+end
+
+function CVodeSetInitStepB(cvode_mem::Ptr{Void},which::Int,hinB::realtype)
+    ccall((:CVodeSetInitStepB,libsundials_cvode),Cint,(Ptr{Void},Cint,realtype),cvode_mem,which,hinB)
+end
+
+function CVodeSetMinStepB(cvode_mem::Ptr{Void},which::Int,hminB::realtype)
+    ccall((:CVodeSetMinStepB,libsundials_cvode),Cint,(Ptr{Void},Cint,realtype),cvode_mem,which,hminB)
+end
+
+function CVodeSetMaxStepB(cvode_mem::Ptr{Void},which::Int,hmaxB::realtype)
+    ccall((:CVodeSetMaxStepB,libsundials_cvode),Cint,(Ptr{Void},Cint,realtype),cvode_mem,which,hmaxB)
+end
+
+function CVodeSetQuadErrConB(cvode_mem::Ptr{Void},which::Int,errconQB::Int)
+    ccall((:CVodeSetQuadErrConB,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint),cvode_mem,which,errconQB)
+end
+
+function CVodeGetB(cvode_mem::Ptr{Void},which::Int,tBret::Vector{realtype},yB::N_Vector)
+    ccall((:CVodeGetB,libsundials_cvode),Cint,(Ptr{Void},Cint,Ptr{realtype},N_Vector),cvode_mem,which,tBret,yB)
+end
+
+function CVodeGetQuadB(cvode_mem::Ptr{Void},which::Int,tBret::Vector{realtype},qB::N_Vector)
+    ccall((:CVodeGetQuadB,libsundials_cvode),Cint,(Ptr{Void},Cint,Ptr{realtype},N_Vector),cvode_mem,which,tBret,qB)
+end
+
+function CVodeGetAdjCVodeBmem(cvode_mem::Ptr{Void},which::Int)
+    ccall((:CVodeGetAdjCVodeBmem,libsundials_cvode),Ptr{Void},(Ptr{Void},Cint),cvode_mem,which)
+end
+
+function CVodeGetAdjY(cvode_mem::Ptr{Void},t::realtype,y::N_Vector)
+    ccall((:CVodeGetAdjY,libsundials_cvode),Cint,(Ptr{Void},realtype,N_Vector),cvode_mem,t,y)
+end
+
+function CVodeGetAdjCheckPointsInfo(cvode_mem::Ptr{Void},ckpnt::Ptr{CVadjCheckPointRec})
+    ccall((:CVodeGetAdjCheckPointsInfo,libsundials_cvode),Cint,(Ptr{Void},Ptr{CVadjCheckPointRec}),cvode_mem,ckpnt)
+end
+
+function CVodeGetAdjDataPointHermite(cvode_mem::Ptr{Void},which::Int,t::Vector{realtype},y::N_Vector,yd::N_Vector)
+    ccall((:CVodeGetAdjDataPointHermite,libsundials_cvode),Cint,(Ptr{Void},Cint,Ptr{realtype},N_Vector,N_Vector),cvode_mem,which,t,y,yd)
+end
+
+function CVodeGetAdjDataPointPolynomial(cvode_mem::Ptr{Void},which::Int,t::Vector{realtype},order::Ptr{Cint},y::N_Vector)
+    ccall((:CVodeGetAdjDataPointPolynomial,libsundials_cvode),Cint,(Ptr{Void},Cint,Ptr{realtype},Ptr{Cint},N_Vector),cvode_mem,which,t,order,y)
+end
+
+function CVodeGetAdjCurrentCheckPoint(cvode_mem::Ptr{Void},addr::Vector{Ptr{Void}})
+    ccall((:CVodeGetAdjCurrentCheckPoint,libsundials_cvode),Cint,(Ptr{Void},Ptr{Ptr{Void}}),cvode_mem,addr)
+end
+
+function cvEwtSet(ycur::N_Vector,weight::N_Vector,data::Ptr{Void})
+    ccall((:cvEwtSet,libsundials_cvode),Cint,(N_Vector,N_Vector,Ptr{Void}),ycur,weight,data)
+end
+
+function cvErrHandler(error_code::Int,_module::Ptr{UInt8},_function::Ptr{UInt8},msg::Ptr{UInt8},data::Ptr{Void})
+    ccall((:cvErrHandler,libsundials_cvode),Void,(Cint,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},Ptr{Void}),error_code,_module,_function,msg,data)
+end
+
+function cvSensRhsWrapper(cv_mem::CVodeMem,time::realtype,ycur::N_Vector,fcur::N_Vector,yScur::Ptr{N_Vector},fScur::Ptr{N_Vector},temp1::N_Vector,temp2::N_Vector)
+    ccall((:cvSensRhsWrapper,libsundials_cvode),Cint,(CVodeMem,realtype,N_Vector,N_Vector,Ptr{N_Vector},Ptr{N_Vector},N_Vector,N_Vector),cv_mem,time,ycur,fcur,yScur,fScur,temp1,temp2)
+end
+
+function cvSensRhs1Wrapper(cv_mem::CVodeMem,time::realtype,ycur::N_Vector,fcur::N_Vector,is::Int,yScur::N_Vector,fScur::N_Vector,temp1::N_Vector,temp2::N_Vector)
+    ccall((:cvSensRhs1Wrapper,libsundials_cvode),Cint,(CVodeMem,realtype,N_Vector,N_Vector,Cint,N_Vector,N_Vector,N_Vector,N_Vector),cv_mem,time,ycur,fcur,is,yScur,fScur,temp1,temp2)
+end
+
+function cvSensRhsInternalDQ(Ns::Int,t::realtype,y::N_Vector,ydot::N_Vector,yS::Ptr{N_Vector},ySdot::Ptr{N_Vector},fS_data::Ptr{Void},tempv::N_Vector,ftemp::N_Vector)
+    ccall((:cvSensRhsInternalDQ,libsundials_cvode),Cint,(Cint,realtype,N_Vector,N_Vector,Ptr{N_Vector},Ptr{N_Vector},Ptr{Void},N_Vector,N_Vector),Ns,t,y,ydot,yS,ySdot,fS_data,tempv,ftemp)
+end
+
+function cvSensRhs1InternalDQ(Ns::Int,t::realtype,y::N_Vector,ydot::N_Vector,is::Int,yS::N_Vector,ySdot::N_Vector,fS_data::Ptr{Void},tempv::N_Vector,ftemp::N_Vector)
+    ccall((:cvSensRhs1InternalDQ,libsundials_cvode),Cint,(Cint,realtype,N_Vector,N_Vector,Cint,N_Vector,N_Vector,Ptr{Void},N_Vector,N_Vector),Ns,t,y,ydot,is,yS,ySdot,fS_data,tempv,ftemp)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvodes/cvodes_spbcgs.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function CVSpbcg(cvode_mem::Ptr{Void},pretype::Int,maxl::Int)
+    ccall((:CVSpbcg,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint),cvode_mem,pretype,maxl)
+end
+
+function CVSpbcgB(cvode_mem::Ptr{Void},which::Int,pretypeB::Int,maxlB::Int)
+    ccall((:CVSpbcgB,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint,Cint),cvode_mem,which,pretypeB,maxlB)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvodes/cvodes_spgmr.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function CVSpgmr(cvode_mem::Ptr{Void},pretype::Int,maxl::Int)
+    ccall((:CVSpgmr,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint),cvode_mem,pretype,maxl)
+end
+
+function CVSpgmrB(cvode_mem::Ptr{Void},which::Int,pretypeB::Int,maxlB::Int)
+    ccall((:CVSpgmrB,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint,Cint),cvode_mem,which,pretypeB,maxlB)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/cvodes/cvodes_sptfqmr.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function CVSpilsSetJacTimesVecFnB(cvode_mem::Ptr{Void},which::Int,jtvB::CVSpilsJacTimesVecFnB)
+    ccall((:CVSpilsSetJacTimesVecFnB,libsundials_cvode),Cint,(Ptr{Void},Cint,CVSpilsJacTimesVecFnB),cvode_mem,which,jtvB)
+end
+
+function CVSptfqmr(cvode_mem::Ptr{Void},pretype::Int,maxl::Int)
+    ccall((:CVSptfqmr,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint),cvode_mem,pretype,maxl)
+end
+
+function CVSptfqmrB(cvode_mem::Ptr{Void},which::Int,pretypeB::Int,maxlB::Int)
+    ccall((:CVSptfqmrB,libsundials_cvode),Cint,(Ptr{Void},Cint,Cint,Cint),cvode_mem,which,pretypeB,maxlB)
+end

--- a/src/ida.jl
+++ b/src/ida.jl
@@ -1,144 +1,680 @@
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/ida/ida.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
 
-recurs_sym_type(ex::Any) = 
-  (ex==None || typeof(ex)==Symbol || length(ex.args)==1) ? eval(ex) : Expr(ex.head, ex.args[1], recurs_sym_type(ex.args[2]))
-macro c(ret_type, func, arg_types, lib)
-  local _arg_types = Expr(:tuple, [recurs_sym_type(a) for a in arg_types.args]...)
-  local _ret_type = recurs_sym_type(ret_type)
-  local _args_in = Any[ symbol(string('a',x)) for x in 1:length(_arg_types.args) ]
-  local _lib = eval(lib)
-  quote
-    $(esc(func))($(_args_in...)) = ccall( ($(string(func)), $(Expr(:quote, _lib)) ), $_ret_type, $_arg_types, $(_args_in...) )
-  end
+function IDACreate()
+    ccall((:IDACreate,libsundials_ida),Ptr{Void},())
 end
 
-macro ctypedef(fake_t,real_t)
-  real_t = recurs_sym_type(real_t)
-  quote
-    typealias $fake_t $real_t
-  end
+function IDASetErrHandlerFn(ida_mem::Ptr{Void},ehfun::IDAErrHandlerFn,eh_data::Ptr{Void})
+    ccall((:IDASetErrHandlerFn,libsundials_ida),Cint,(Ptr{Void},IDAErrHandlerFn,Ptr{Void}),ida_mem,ehfun,eh_data)
 end
 
-# header: /usr/local/include/ida/ida_band.h
-@ctypedef IDADlsDenseJacFn Ptr{:Void}
-@ctypedef IDADlsBandJacFn Ptr{:Void}
-@c Int32 IDADlsSetDenseJacFn (Ptr{:None},:IDADlsDenseJacFn) shlib
-@c Int32 IDADlsSetBandJacFn (Ptr{:None},:IDADlsBandJacFn) shlib
-@c Int32 IDADlsGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 IDADlsGetNumJacEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDADlsGetNumResEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDADlsGetLastFlag (Ptr{:None},Ptr{:Clong}) shlib
-@c Ptr{:Uint8} IDADlsGetReturnFlagName (:Clong,) shlib
-@c Int32 IDABand (Ptr{:None},:Clong,:Clong,:Clong) shlib
+function IDASetErrFile(ida_mem::Ptr{Void},errfp::Ptr{Void})
+    ccall((:IDASetErrFile,libsundials_ida),Cint,(Ptr{Void},Ptr{Void}),ida_mem,errfp)
+end
 
-# header: /usr/local/include/ida/ida_bbdpre.h
-@ctypedef IDABBDLocalFn Ptr{:Void}
-@ctypedef IDABBDCommFn Ptr{:Void}
-@c Int32 IDABBDPrecInit (Ptr{:None},:Clong,:Clong,:Clong,:Clong,:Clong,:realtype,:IDABBDLocalFn,:IDABBDCommFn) shlib
-@c Int32 IDABBDPrecReInit (Ptr{:None},:Clong,:Clong,:realtype) shlib
-@c Int32 IDABBDPrecGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 IDABBDPrecGetNumGfnEvals (Ptr{:None},Ptr{:Clong}) shlib
+function IDASetUserData(ida_mem::Ptr{Void},user_data::Ptr{Void})
+    ccall((:IDASetUserData,libsundials_ida),Cint,(Ptr{Void},Ptr{Void}),ida_mem,user_data)
+end
 
-# header: /usr/local/include/ida/ida_dense.h
-@c Int32 IDADense (Ptr{:None},:Clong) shlib
+function IDASetMaxOrd(ida_mem::Ptr{Void},maxord::Int)
+    ccall((:IDASetMaxOrd,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxord)
+end
 
-# header: /usr/local/include/ida/ida_direct.h
+function IDASetMaxNumSteps(ida_mem::Ptr{Void},mxsteps::Int)
+    ccall((:IDASetMaxNumSteps,libsundials_ida),Cint,(Ptr{Void},Clong),ida_mem,mxsteps)
+end
 
-# header: /usr/local/include/ida/ida.h
-@ctypedef IDAResFn Ptr{:Void}
-@ctypedef IDARootFn Ptr{:Void}
-@ctypedef IDAEwtFn Ptr{:Void}
-@ctypedef IDAErrHandlerFn Ptr{:Void}
-@c Ptr{:None} IDACreate () shlib
-@c Int32 IDASetErrHandlerFn (Ptr{:None},:IDAErrHandlerFn,Ptr{:None}) shlib
-@c Int32 IDASetErrFile (Ptr{:None},Ptr{:FILE}) shlib
-@c Int32 IDASetUserData (Ptr{:None},Ptr{:None}) shlib
-@c Int32 IDASetMaxOrd (Ptr{:None},:Int32) shlib
-@c Int32 IDASetMaxNumSteps (Ptr{:None},:Clong) shlib
-@c Int32 IDASetInitStep (Ptr{:None},:realtype) shlib
-@c Int32 IDASetMaxStep (Ptr{:None},:realtype) shlib
-@c Int32 IDASetStopTime (Ptr{:None},:realtype) shlib
-@c Int32 IDASetNonlinConvCoef (Ptr{:None},:realtype) shlib
-@c Int32 IDASetMaxErrTestFails (Ptr{:None},:Int32) shlib
-@c Int32 IDASetMaxNonlinIters (Ptr{:None},:Int32) shlib
-@c Int32 IDASetMaxConvFails (Ptr{:None},:Int32) shlib
-@c Int32 IDASetSuppressAlg (Ptr{:None},:Int32) shlib
-@c Int32 IDASetId (Ptr{:None},:N_Vector) shlib
-@c Int32 IDASetConstraints (Ptr{:None},:N_Vector) shlib
-@c Int32 IDASetRootDirection (Ptr{:None},Ptr{:Int32}) shlib
-@c Int32 IDASetNoInactiveRootWarn (Ptr{:None},) shlib
-@c Int32 IDAInit (Ptr{:None},:IDAResFn,:realtype,:N_Vector,:N_Vector) shlib
-@c Int32 IDAReInit (Ptr{:None},:realtype,:N_Vector,:N_Vector) shlib
-@c Int32 IDASStolerances (Ptr{:None},:realtype,:realtype) shlib
-@c Int32 IDASVtolerances (Ptr{:None},:realtype,:N_Vector) shlib
-@c Int32 IDAWFtolerances (Ptr{:None},:IDAEwtFn) shlib
-@c Int32 IDASetNonlinConvCoefIC (Ptr{:None},:realtype) shlib
-@c Int32 IDASetMaxNumStepsIC (Ptr{:None},:Int32) shlib
-@c Int32 IDASetMaxNumJacsIC (Ptr{:None},:Int32) shlib
-@c Int32 IDASetMaxNumItersIC (Ptr{:None},:Int32) shlib
-@c Int32 IDASetLineSearchOffIC (Ptr{:None},:Int32) shlib
-@c Int32 IDASetStepToleranceIC (Ptr{:None},:realtype) shlib
-@c Int32 IDARootInit (Ptr{:None},:Int32,:IDARootFn) shlib
-@c Int32 IDACalcIC (Ptr{:None},:Int32,:realtype) shlib
-@c Int32 IDASolve (Ptr{:None},:realtype,Ptr{:realtype},:N_Vector,:N_Vector,:Int32) shlib
-@c Int32 IDAGetDky (Ptr{:None},:realtype,:Int32,:N_Vector) shlib
-@c Int32 IDAGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 IDAGetNumSteps (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetNumResEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetNumLinSolvSetups (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetNumErrTestFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetNumBacktrackOps (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetConsistentIC (Ptr{:None},:N_Vector,:N_Vector) shlib
-@c Int32 IDAGetLastOrder (Ptr{:None},Ptr{:Int32}) shlib
-@c Int32 IDAGetCurrentOrder (Ptr{:None},Ptr{:Int32}) shlib
-@c Int32 IDAGetActualInitStep (Ptr{:None},Ptr{:realtype}) shlib
-@c Int32 IDAGetLastStep (Ptr{:None},Ptr{:realtype}) shlib
-@c Int32 IDAGetCurrentStep (Ptr{:None},Ptr{:realtype}) shlib
-@c Int32 IDAGetCurrentTime (Ptr{:None},Ptr{:realtype}) shlib
-@c Int32 IDAGetTolScaleFactor (Ptr{:None},Ptr{:realtype}) shlib
-@c Int32 IDAGetErrWeights (Ptr{:None},:N_Vector) shlib
-@c Int32 IDAGetEstLocalErrors (Ptr{:None},:N_Vector) shlib
-@c Int32 IDAGetNumGEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetRootInfo (Ptr{:None},Ptr{:Int32}) shlib
-@c Int32 IDAGetIntegratorStats (Ptr{:None},Ptr{:Clong},Ptr{:Clong},Ptr{:Clong},Ptr{:Clong},Ptr{:Int32},Ptr{:Int32},Ptr{:realtype},Ptr{:realtype},Ptr{:realtype},Ptr{:realtype}) shlib
-@c Int32 IDAGetNumNonlinSolvIters (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetNumNonlinSolvConvFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetNonlinSolvStats (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Ptr{:Uint8} IDAGetReturnFlagName (:Clong,) shlib
-@c None IDAFree (Ptr{Ptr{:None}},) shlib
+function IDASetInitStep(ida_mem::Ptr{Void},hin::realtype)
+    ccall((:IDASetInitStep,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,hin)
+end
 
-# header: /usr/local/include/ida/ida_impl.h
-@ctypedef IDAMem Ptr{:Void}
-@c Int32 IDAEwtSet (:N_Vector,:N_Vector,Ptr{:None}) shlib
-@c None IDAProcessError (:IDAMem,:Int32,Ptr{:Uint8},Ptr{:Uint8},Ptr{:Uint8}) shlib
-@c None IDAErrHandler (:Int32,Ptr{:Uint8},Ptr{:Uint8},Ptr{:Uint8},Ptr{:None}) shlib
+function IDASetMaxStep(ida_mem::Ptr{Void},hmax::realtype)
+    ccall((:IDASetMaxStep,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,hmax)
+end
 
-# header: /usr/local/include/ida/ida_spbcgs.h
-@ctypedef IDASpilsPrecSetupFn Ptr{:Void}
-@ctypedef IDASpilsPrecSolveFn Ptr{:Void}
-@ctypedef IDASpilsJacTimesVecFn Ptr{:Void}
-@c Int32 IDASpilsSetPreconditioner (Ptr{:None},:IDASpilsPrecSetupFn,:IDASpilsPrecSolveFn) shlib
-@c Int32 IDASpilsSetJacTimesVecFn (Ptr{:None},:IDASpilsJacTimesVecFn) shlib
-@c Int32 IDASpilsSetGSType (Ptr{:None},:Int32) shlib
-@c Int32 IDASpilsSetMaxRestarts (Ptr{:None},:Int32) shlib
-@c Int32 IDASpilsSetMaxl (Ptr{:None},:Int32) shlib
-@c Int32 IDASpilsSetEpsLin (Ptr{:None},:realtype) shlib
-@c Int32 IDASpilsSetIncrementFactor (Ptr{:None},:realtype) shlib
-@c Int32 IDASpilsGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 IDASpilsGetNumPrecEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDASpilsGetNumPrecSolves (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDASpilsGetNumLinIters (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDASpilsGetNumConvFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDASpilsGetNumJtimesEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDASpilsGetNumResEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDASpilsGetLastFlag (Ptr{:None},Ptr{:Clong}) shlib
-@c Ptr{:Uint8} IDASpilsGetReturnFlagName (:Clong,) shlib
-@c Int32 IDASpbcg (Ptr{:None},:Int32) shlib
+function IDASetStopTime(ida_mem::Ptr{Void},tstop::realtype)
+    ccall((:IDASetStopTime,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,tstop)
+end
 
-# header: /usr/local/include/ida/ida_spgmr.h
-@c Int32 IDASpgmr (Ptr{:None},:Int32) shlib
+function IDASetNonlinConvCoef(ida_mem::Ptr{Void},epcon::realtype)
+    ccall((:IDASetNonlinConvCoef,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,epcon)
+end
 
-# header: /usr/local/include/ida/ida_spils.h
+function IDASetMaxErrTestFails(ida_mem::Ptr{Void},maxnef::Int)
+    ccall((:IDASetMaxErrTestFails,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxnef)
+end
 
-# header: /usr/local/include/ida/ida_sptfqmr.h
-@c Int32 IDASptfqmr (Ptr{:None},:Int32) shlib
+function IDASetMaxNonlinIters(ida_mem::Ptr{Void},maxcor::Int)
+    ccall((:IDASetMaxNonlinIters,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxcor)
+end
 
+function IDASetMaxConvFails(ida_mem::Ptr{Void},maxncf::Int)
+    ccall((:IDASetMaxConvFails,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxncf)
+end
+
+function IDASetSuppressAlg(ida_mem::Ptr{Void},suppressalg::Int)
+    ccall((:IDASetSuppressAlg,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,suppressalg)
+end
+
+function IDASetId(ida_mem::Ptr{Void},id::N_Vector)
+    ccall((:IDASetId,libsundials_ida),Cint,(Ptr{Void},N_Vector),ida_mem,id)
+end
+
+function IDASetConstraints(ida_mem::Ptr{Void},constraints::N_Vector)
+    ccall((:IDASetConstraints,libsundials_ida),Cint,(Ptr{Void},N_Vector),ida_mem,constraints)
+end
+
+function IDASetRootDirection(ida_mem::Ptr{Void},rootdir::Ptr{Cint})
+    ccall((:IDASetRootDirection,libsundials_ida),Cint,(Ptr{Void},Ptr{Cint}),ida_mem,rootdir)
+end
+
+function IDASetNoInactiveRootWarn(ida_mem::Ptr{Void})
+    ccall((:IDASetNoInactiveRootWarn,libsundials_ida),Cint,(Ptr{Void},),ida_mem)
+end
+
+function IDAInit(ida_mem::Ptr{Void},res::IDAResFn,t0::realtype,yy0::N_Vector,yp0::N_Vector)
+    ccall((:IDAInit,libsundials_ida),Cint,(Ptr{Void},IDAResFn,realtype,N_Vector,N_Vector),ida_mem,res,t0,yy0,yp0)
+end
+
+function IDAReInit(ida_mem::Ptr{Void},t0::realtype,yy0::N_Vector,yp0::N_Vector)
+    ccall((:IDAReInit,libsundials_ida),Cint,(Ptr{Void},realtype,N_Vector,N_Vector),ida_mem,t0,yy0,yp0)
+end
+
+function IDASStolerances(ida_mem::Ptr{Void},reltol::realtype,abstol::realtype)
+    ccall((:IDASStolerances,libsundials_ida),Cint,(Ptr{Void},realtype,realtype),ida_mem,reltol,abstol)
+end
+
+function IDASVtolerances(ida_mem::Ptr{Void},reltol::realtype,abstol::N_Vector)
+    ccall((:IDASVtolerances,libsundials_ida),Cint,(Ptr{Void},realtype,N_Vector),ida_mem,reltol,abstol)
+end
+
+function IDAWFtolerances(ida_mem::Ptr{Void},efun::IDAEwtFn)
+    ccall((:IDAWFtolerances,libsundials_ida),Cint,(Ptr{Void},IDAEwtFn),ida_mem,efun)
+end
+
+function IDASetNonlinConvCoefIC(ida_mem::Ptr{Void},epiccon::realtype)
+    ccall((:IDASetNonlinConvCoefIC,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,epiccon)
+end
+
+function IDASetMaxNumStepsIC(ida_mem::Ptr{Void},maxnh::Int)
+    ccall((:IDASetMaxNumStepsIC,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxnh)
+end
+
+function IDASetMaxNumJacsIC(ida_mem::Ptr{Void},maxnj::Int)
+    ccall((:IDASetMaxNumJacsIC,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxnj)
+end
+
+function IDASetMaxNumItersIC(ida_mem::Ptr{Void},maxnit::Int)
+    ccall((:IDASetMaxNumItersIC,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxnit)
+end
+
+function IDASetLineSearchOffIC(ida_mem::Ptr{Void},lsoff::Int)
+    ccall((:IDASetLineSearchOffIC,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,lsoff)
+end
+
+function IDASetStepToleranceIC(ida_mem::Ptr{Void},steptol::realtype)
+    ccall((:IDASetStepToleranceIC,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,steptol)
+end
+
+function IDARootInit(ida_mem::Ptr{Void},nrtfn::Int,g::IDARootFn)
+    ccall((:IDARootInit,libsundials_ida),Cint,(Ptr{Void},Cint,IDARootFn),ida_mem,nrtfn,g)
+end
+
+function IDACalcIC(ida_mem::Ptr{Void},icopt::Int,tout1::realtype)
+    ccall((:IDACalcIC,libsundials_ida),Cint,(Ptr{Void},Cint,realtype),ida_mem,icopt,tout1)
+end
+
+function IDASolve(ida_mem::Ptr{Void},tout::realtype,tret::Vector{realtype},yret::N_Vector,ypret::N_Vector,itask::Int)
+    ccall((:IDASolve,libsundials_ida),Cint,(Ptr{Void},realtype,Ptr{realtype},N_Vector,N_Vector,Cint),ida_mem,tout,tret,yret,ypret,itask)
+end
+
+function IDAGetDky(ida_mem::Ptr{Void},t::realtype,k::Int,dky::N_Vector)
+    ccall((:IDAGetDky,libsundials_ida),Cint,(Ptr{Void},realtype,Cint,N_Vector),ida_mem,t,k,dky)
+end
+
+function IDAGetWorkSpace(ida_mem::Ptr{Void},lenrw::Ptr{Clong},leniw::Ptr{Clong})
+    ccall((:IDAGetWorkSpace,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),ida_mem,lenrw,leniw)
+end
+
+function IDAGetNumSteps(ida_mem::Ptr{Void},nsteps::Ptr{Clong})
+    ccall((:IDAGetNumSteps,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nsteps)
+end
+
+function IDAGetNumResEvals(ida_mem::Ptr{Void},nrevals::Ptr{Clong})
+    ccall((:IDAGetNumResEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nrevals)
+end
+
+function IDAGetNumLinSolvSetups(ida_mem::Ptr{Void},nlinsetups::Ptr{Clong})
+    ccall((:IDAGetNumLinSolvSetups,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nlinsetups)
+end
+
+function IDAGetNumErrTestFails(ida_mem::Ptr{Void},netfails::Ptr{Clong})
+    ccall((:IDAGetNumErrTestFails,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,netfails)
+end
+
+function IDAGetNumBacktrackOps(ida_mem::Ptr{Void},nbacktr::Ptr{Clong})
+    ccall((:IDAGetNumBacktrackOps,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nbacktr)
+end
+
+function IDAGetConsistentIC(ida_mem::Ptr{Void},yy0_mod::N_Vector,yp0_mod::N_Vector)
+    ccall((:IDAGetConsistentIC,libsundials_ida),Cint,(Ptr{Void},N_Vector,N_Vector),ida_mem,yy0_mod,yp0_mod)
+end
+
+function IDAGetLastOrder(ida_mem::Ptr{Void},klast::Ptr{Cint})
+    ccall((:IDAGetLastOrder,libsundials_ida),Cint,(Ptr{Void},Ptr{Cint}),ida_mem,klast)
+end
+
+function IDAGetCurrentOrder(ida_mem::Ptr{Void},kcur::Ptr{Cint})
+    ccall((:IDAGetCurrentOrder,libsundials_ida),Cint,(Ptr{Void},Ptr{Cint}),ida_mem,kcur)
+end
+
+function IDAGetActualInitStep(ida_mem::Ptr{Void},hinused::Vector{realtype})
+    ccall((:IDAGetActualInitStep,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype}),ida_mem,hinused)
+end
+
+function IDAGetLastStep(ida_mem::Ptr{Void},hlast::Vector{realtype})
+    ccall((:IDAGetLastStep,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype}),ida_mem,hlast)
+end
+
+function IDAGetCurrentStep(ida_mem::Ptr{Void},hcur::Vector{realtype})
+    ccall((:IDAGetCurrentStep,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype}),ida_mem,hcur)
+end
+
+function IDAGetCurrentTime(ida_mem::Ptr{Void},tcur::Vector{realtype})
+    ccall((:IDAGetCurrentTime,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype}),ida_mem,tcur)
+end
+
+function IDAGetTolScaleFactor(ida_mem::Ptr{Void},tolsfact::Vector{realtype})
+    ccall((:IDAGetTolScaleFactor,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype}),ida_mem,tolsfact)
+end
+
+function IDAGetErrWeights(ida_mem::Ptr{Void},eweight::N_Vector)
+    ccall((:IDAGetErrWeights,libsundials_ida),Cint,(Ptr{Void},N_Vector),ida_mem,eweight)
+end
+
+function IDAGetEstLocalErrors(ida_mem::Ptr{Void},ele::N_Vector)
+    ccall((:IDAGetEstLocalErrors,libsundials_ida),Cint,(Ptr{Void},N_Vector),ida_mem,ele)
+end
+
+function IDAGetNumGEvals(ida_mem::Ptr{Void},ngevals::Ptr{Clong})
+    ccall((:IDAGetNumGEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,ngevals)
+end
+
+function IDAGetRootInfo(ida_mem::Ptr{Void},rootsfound::Ptr{Cint})
+    ccall((:IDAGetRootInfo,libsundials_ida),Cint,(Ptr{Void},Ptr{Cint}),ida_mem,rootsfound)
+end
+
+function IDAGetIntegratorStats(ida_mem::Ptr{Void},nsteps::Ptr{Clong},nrevals::Ptr{Clong},nlinsetups::Ptr{Clong},netfails::Ptr{Clong},qlast::Ptr{Cint},qcur::Ptr{Cint},hinused::Vector{realtype},hlast::Vector{realtype},hcur::Vector{realtype},tcur::Vector{realtype})
+    ccall((:IDAGetIntegratorStats,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Cint},Ptr{Cint},Ptr{realtype},Ptr{realtype},Ptr{realtype},Ptr{realtype}),ida_mem,nsteps,nrevals,nlinsetups,netfails,qlast,qcur,hinused,hlast,hcur,tcur)
+end
+
+function IDAGetNumNonlinSolvIters(ida_mem::Ptr{Void},nniters::Ptr{Clong})
+    ccall((:IDAGetNumNonlinSolvIters,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nniters)
+end
+
+function IDAGetNumNonlinSolvConvFails(ida_mem::Ptr{Void},nncfails::Ptr{Clong})
+    ccall((:IDAGetNumNonlinSolvConvFails,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nncfails)
+end
+
+function IDAGetNonlinSolvStats(ida_mem::Ptr{Void},nniters::Ptr{Clong},nncfails::Ptr{Clong})
+    ccall((:IDAGetNonlinSolvStats,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),ida_mem,nniters,nncfails)
+end
+
+function IDAGetReturnFlagName(flag::Int)
+    ccall((:IDAGetReturnFlagName,libsundials_ida),Ptr{UInt8},(Clong,),flag)
+end
+
+function IDAFree(ida_mem::Vector{Ptr{Void}})
+    ccall((:IDAFree,libsundials_ida),Void,(Ptr{Ptr{Void}},),ida_mem)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/ida/ida_direct.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+
+function IDADlsSetDenseJacFn(ida_mem::Ptr{Void},jac::IDADlsDenseJacFn)
+    ccall((:IDADlsSetDenseJacFn,libsundials_ida),Cint,(Ptr{Void},IDADlsDenseJacFn),ida_mem,jac)
+end
+
+function IDADlsSetBandJacFn(ida_mem::Ptr{Void},jac::IDADlsBandJacFn)
+    ccall((:IDADlsSetBandJacFn,libsundials_ida),Cint,(Ptr{Void},IDADlsBandJacFn),ida_mem,jac)
+end
+
+function IDADlsGetWorkSpace(ida_mem::Ptr{Void},lenrwLS::Ptr{Clong},leniwLS::Ptr{Clong})
+    ccall((:IDADlsGetWorkSpace,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),ida_mem,lenrwLS,leniwLS)
+end
+
+function IDADlsGetNumJacEvals(ida_mem::Ptr{Void},njevals::Ptr{Clong})
+    ccall((:IDADlsGetNumJacEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,njevals)
+end
+
+function IDADlsGetNumResEvals(ida_mem::Ptr{Void},nfevalsLS::Ptr{Clong})
+    ccall((:IDADlsGetNumResEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nfevalsLS)
+end
+
+function IDADlsGetLastFlag(ida_mem::Ptr{Void},flag::Ptr{Clong})
+    ccall((:IDADlsGetLastFlag,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,flag)
+end
+
+function IDADlsGetReturnFlagName(flag::Int)
+    ccall((:IDADlsGetReturnFlagName,libsundials_ida),Ptr{UInt8},(Clong,),flag)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/ida/ida_spils.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+
+function IDASpilsSetPreconditioner(ida_mem::Ptr{Void},pset::IDASpilsPrecSetupFn,psolve::IDASpilsPrecSolveFn)
+    ccall((:IDASpilsSetPreconditioner,libsundials_ida),Cint,(Ptr{Void},IDASpilsPrecSetupFn,IDASpilsPrecSolveFn),ida_mem,pset,psolve)
+end
+
+function IDASpilsSetJacTimesVecFn(ida_mem::Ptr{Void},jtv::IDASpilsJacTimesVecFn)
+    ccall((:IDASpilsSetJacTimesVecFn,libsundials_ida),Cint,(Ptr{Void},IDASpilsJacTimesVecFn),ida_mem,jtv)
+end
+
+function IDASpilsSetGSType(ida_mem::Ptr{Void},gstype::Int)
+    ccall((:IDASpilsSetGSType,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,gstype)
+end
+
+function IDASpilsSetMaxRestarts(ida_mem::Ptr{Void},maxrs::Int)
+    ccall((:IDASpilsSetMaxRestarts,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxrs)
+end
+
+function IDASpilsSetMaxl(ida_mem::Ptr{Void},maxl::Int)
+    ccall((:IDASpilsSetMaxl,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxl)
+end
+
+function IDASpilsSetEpsLin(ida_mem::Ptr{Void},eplifac::realtype)
+    ccall((:IDASpilsSetEpsLin,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,eplifac)
+end
+
+function IDASpilsSetIncrementFactor(ida_mem::Ptr{Void},dqincfac::realtype)
+    ccall((:IDASpilsSetIncrementFactor,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,dqincfac)
+end
+
+function IDASpilsGetWorkSpace(ida_mem::Ptr{Void},lenrwLS::Ptr{Clong},leniwLS::Ptr{Clong})
+    ccall((:IDASpilsGetWorkSpace,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),ida_mem,lenrwLS,leniwLS)
+end
+
+function IDASpilsGetNumPrecEvals(ida_mem::Ptr{Void},npevals::Ptr{Clong})
+    ccall((:IDASpilsGetNumPrecEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,npevals)
+end
+
+function IDASpilsGetNumPrecSolves(ida_mem::Ptr{Void},npsolves::Ptr{Clong})
+    ccall((:IDASpilsGetNumPrecSolves,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,npsolves)
+end
+
+function IDASpilsGetNumLinIters(ida_mem::Ptr{Void},nliters::Ptr{Clong})
+    ccall((:IDASpilsGetNumLinIters,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nliters)
+end
+
+function IDASpilsGetNumConvFails(ida_mem::Ptr{Void},nlcfails::Ptr{Clong})
+    ccall((:IDASpilsGetNumConvFails,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nlcfails)
+end
+
+function IDASpilsGetNumJtimesEvals(ida_mem::Ptr{Void},njvevals::Ptr{Clong})
+    ccall((:IDASpilsGetNumJtimesEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,njvevals)
+end
+
+function IDASpilsGetNumResEvals(ida_mem::Ptr{Void},nrevalsLS::Ptr{Clong})
+    ccall((:IDASpilsGetNumResEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nrevalsLS)
+end
+
+function IDASpilsGetLastFlag(ida_mem::Ptr{Void},flag::Ptr{Clong})
+    ccall((:IDASpilsGetLastFlag,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,flag)
+end
+
+function IDASpilsGetReturnFlagName(flag::Int)
+    ccall((:IDASpilsGetReturnFlagName,libsundials_ida),Ptr{UInt8},(Clong,),flag)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/ida/ida_band.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function IDADlsSetDenseJacFn(ida_mem::Ptr{Void},jac::IDADlsDenseJacFn)
+    ccall((:IDADlsSetDenseJacFn,libsundials_ida),Cint,(Ptr{Void},IDADlsDenseJacFn),ida_mem,jac)
+end
+
+function IDADlsSetBandJacFn(ida_mem::Ptr{Void},jac::IDADlsBandJacFn)
+    ccall((:IDADlsSetBandJacFn,libsundials_ida),Cint,(Ptr{Void},IDADlsBandJacFn),ida_mem,jac)
+end
+
+function IDADlsGetWorkSpace(ida_mem::Ptr{Void},lenrwLS::Ptr{Clong},leniwLS::Ptr{Clong})
+    ccall((:IDADlsGetWorkSpace,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),ida_mem,lenrwLS,leniwLS)
+end
+
+function IDADlsGetNumJacEvals(ida_mem::Ptr{Void},njevals::Ptr{Clong})
+    ccall((:IDADlsGetNumJacEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,njevals)
+end
+
+function IDADlsGetNumResEvals(ida_mem::Ptr{Void},nfevalsLS::Ptr{Clong})
+    ccall((:IDADlsGetNumResEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nfevalsLS)
+end
+
+function IDADlsGetLastFlag(ida_mem::Ptr{Void},flag::Ptr{Clong})
+    ccall((:IDADlsGetLastFlag,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,flag)
+end
+
+function IDADlsGetReturnFlagName(flag::Int)
+    ccall((:IDADlsGetReturnFlagName,libsundials_ida),Ptr{UInt8},(Clong,),flag)
+end
+
+function IDABand(ida_mem::Ptr{Void},Neq::Int,mupper::Int,mlower::Int)
+    ccall((:IDABand,libsundials_ida),Cint,(Ptr{Void},Clong,Clong,Clong),ida_mem,Neq,mupper,mlower)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/ida/ida_bbdpre.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function IDABBDPrecInit(ida_mem::Ptr{Void},Nlocal::Int,mudq::Int,mldq::Int,mukeep::Int,mlkeep::Int,dq_rel_yy::realtype,Gres::IDABBDLocalFn,Gcomm::IDABBDCommFn)
+    ccall((:IDABBDPrecInit,libsundials_ida),Cint,(Ptr{Void},Clong,Clong,Clong,Clong,Clong,realtype,IDABBDLocalFn,IDABBDCommFn),ida_mem,Nlocal,mudq,mldq,mukeep,mlkeep,dq_rel_yy,Gres,Gcomm)
+end
+
+function IDABBDPrecReInit(ida_mem::Ptr{Void},mudq::Int,mldq::Int,dq_rel_yy::realtype)
+    ccall((:IDABBDPrecReInit,libsundials_ida),Cint,(Ptr{Void},Clong,Clong,realtype),ida_mem,mudq,mldq,dq_rel_yy)
+end
+
+function IDABBDPrecGetWorkSpace(ida_mem::Ptr{Void},lenrwBBDP::Ptr{Clong},leniwBBDP::Ptr{Clong})
+    ccall((:IDABBDPrecGetWorkSpace,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),ida_mem,lenrwBBDP,leniwBBDP)
+end
+
+function IDABBDPrecGetNumGfnEvals(ida_mem::Ptr{Void},ngevalsBBDP::Ptr{Clong})
+    ccall((:IDABBDPrecGetNumGfnEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,ngevalsBBDP)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/ida/ida_dense.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+
+function IDADense(ida_mem::Ptr{Void},Neq::Int)
+    ccall((:IDADense,libsundials_ida),Cint,(Ptr{Void},Clong),ida_mem,Neq)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/ida/ida_impl.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+
+function IDACreate()
+    ccall((:IDACreate,libsundials_ida),Ptr{Void},())
+end
+
+function IDASetErrHandlerFn(ida_mem::Ptr{Void},ehfun::IDAErrHandlerFn,eh_data::Ptr{Void})
+    ccall((:IDASetErrHandlerFn,libsundials_ida),Cint,(Ptr{Void},IDAErrHandlerFn,Ptr{Void}),ida_mem,ehfun,eh_data)
+end
+
+function IDASetErrFile(ida_mem::Ptr{Void},errfp::Ptr{Void})
+    ccall((:IDASetErrFile,libsundials_ida),Cint,(Ptr{Void},Ptr{Void}),ida_mem,errfp)
+end
+
+function IDASetUserData(ida_mem::Ptr{Void},user_data::Ptr{Void})
+    ccall((:IDASetUserData,libsundials_ida),Cint,(Ptr{Void},Ptr{Void}),ida_mem,user_data)
+end
+
+function IDASetMaxOrd(ida_mem::Ptr{Void},maxord::Int)
+    ccall((:IDASetMaxOrd,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxord)
+end
+
+function IDASetMaxNumSteps(ida_mem::Ptr{Void},mxsteps::Int)
+    ccall((:IDASetMaxNumSteps,libsundials_ida),Cint,(Ptr{Void},Clong),ida_mem,mxsteps)
+end
+
+function IDASetInitStep(ida_mem::Ptr{Void},hin::realtype)
+    ccall((:IDASetInitStep,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,hin)
+end
+
+function IDASetMaxStep(ida_mem::Ptr{Void},hmax::realtype)
+    ccall((:IDASetMaxStep,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,hmax)
+end
+
+function IDASetStopTime(ida_mem::Ptr{Void},tstop::realtype)
+    ccall((:IDASetStopTime,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,tstop)
+end
+
+function IDASetNonlinConvCoef(ida_mem::Ptr{Void},epcon::realtype)
+    ccall((:IDASetNonlinConvCoef,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,epcon)
+end
+
+function IDASetMaxErrTestFails(ida_mem::Ptr{Void},maxnef::Int)
+    ccall((:IDASetMaxErrTestFails,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxnef)
+end
+
+function IDASetMaxNonlinIters(ida_mem::Ptr{Void},maxcor::Int)
+    ccall((:IDASetMaxNonlinIters,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxcor)
+end
+
+function IDASetMaxConvFails(ida_mem::Ptr{Void},maxncf::Int)
+    ccall((:IDASetMaxConvFails,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxncf)
+end
+
+function IDASetSuppressAlg(ida_mem::Ptr{Void},suppressalg::Int)
+    ccall((:IDASetSuppressAlg,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,suppressalg)
+end
+
+function IDASetId(ida_mem::Ptr{Void},id::N_Vector)
+    ccall((:IDASetId,libsundials_ida),Cint,(Ptr{Void},N_Vector),ida_mem,id)
+end
+
+function IDASetConstraints(ida_mem::Ptr{Void},constraints::N_Vector)
+    ccall((:IDASetConstraints,libsundials_ida),Cint,(Ptr{Void},N_Vector),ida_mem,constraints)
+end
+
+function IDASetRootDirection(ida_mem::Ptr{Void},rootdir::Ptr{Cint})
+    ccall((:IDASetRootDirection,libsundials_ida),Cint,(Ptr{Void},Ptr{Cint}),ida_mem,rootdir)
+end
+
+function IDASetNoInactiveRootWarn(ida_mem::Ptr{Void})
+    ccall((:IDASetNoInactiveRootWarn,libsundials_ida),Cint,(Ptr{Void},),ida_mem)
+end
+
+function IDAInit(ida_mem::Ptr{Void},res::IDAResFn,t0::realtype,yy0::N_Vector,yp0::N_Vector)
+    ccall((:IDAInit,libsundials_ida),Cint,(Ptr{Void},IDAResFn,realtype,N_Vector,N_Vector),ida_mem,res,t0,yy0,yp0)
+end
+
+function IDAReInit(ida_mem::Ptr{Void},t0::realtype,yy0::N_Vector,yp0::N_Vector)
+    ccall((:IDAReInit,libsundials_ida),Cint,(Ptr{Void},realtype,N_Vector,N_Vector),ida_mem,t0,yy0,yp0)
+end
+
+function IDASStolerances(ida_mem::Ptr{Void},reltol::realtype,abstol::realtype)
+    ccall((:IDASStolerances,libsundials_ida),Cint,(Ptr{Void},realtype,realtype),ida_mem,reltol,abstol)
+end
+
+function IDASVtolerances(ida_mem::Ptr{Void},reltol::realtype,abstol::N_Vector)
+    ccall((:IDASVtolerances,libsundials_ida),Cint,(Ptr{Void},realtype,N_Vector),ida_mem,reltol,abstol)
+end
+
+function IDAWFtolerances(ida_mem::Ptr{Void},efun::IDAEwtFn)
+    ccall((:IDAWFtolerances,libsundials_ida),Cint,(Ptr{Void},IDAEwtFn),ida_mem,efun)
+end
+
+function IDASetNonlinConvCoefIC(ida_mem::Ptr{Void},epiccon::realtype)
+    ccall((:IDASetNonlinConvCoefIC,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,epiccon)
+end
+
+function IDASetMaxNumStepsIC(ida_mem::Ptr{Void},maxnh::Int)
+    ccall((:IDASetMaxNumStepsIC,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxnh)
+end
+
+function IDASetMaxNumJacsIC(ida_mem::Ptr{Void},maxnj::Int)
+    ccall((:IDASetMaxNumJacsIC,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxnj)
+end
+
+function IDASetMaxNumItersIC(ida_mem::Ptr{Void},maxnit::Int)
+    ccall((:IDASetMaxNumItersIC,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxnit)
+end
+
+function IDASetLineSearchOffIC(ida_mem::Ptr{Void},lsoff::Int)
+    ccall((:IDASetLineSearchOffIC,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,lsoff)
+end
+
+function IDASetStepToleranceIC(ida_mem::Ptr{Void},steptol::realtype)
+    ccall((:IDASetStepToleranceIC,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,steptol)
+end
+
+function IDARootInit(ida_mem::Ptr{Void},nrtfn::Int,g::IDARootFn)
+    ccall((:IDARootInit,libsundials_ida),Cint,(Ptr{Void},Cint,IDARootFn),ida_mem,nrtfn,g)
+end
+
+function IDACalcIC(ida_mem::Ptr{Void},icopt::Int,tout1::realtype)
+    ccall((:IDACalcIC,libsundials_ida),Cint,(Ptr{Void},Cint,realtype),ida_mem,icopt,tout1)
+end
+
+function IDASolve(ida_mem::Ptr{Void},tout::realtype,tret::Vector{realtype},yret::N_Vector,ypret::N_Vector,itask::Int)
+    ccall((:IDASolve,libsundials_ida),Cint,(Ptr{Void},realtype,Ptr{realtype},N_Vector,N_Vector,Cint),ida_mem,tout,tret,yret,ypret,itask)
+end
+
+function IDAGetDky(ida_mem::Ptr{Void},t::realtype,k::Int,dky::N_Vector)
+    ccall((:IDAGetDky,libsundials_ida),Cint,(Ptr{Void},realtype,Cint,N_Vector),ida_mem,t,k,dky)
+end
+
+function IDAGetWorkSpace(ida_mem::Ptr{Void},lenrw::Ptr{Clong},leniw::Ptr{Clong})
+    ccall((:IDAGetWorkSpace,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),ida_mem,lenrw,leniw)
+end
+
+function IDAGetNumSteps(ida_mem::Ptr{Void},nsteps::Ptr{Clong})
+    ccall((:IDAGetNumSteps,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nsteps)
+end
+
+function IDAGetNumResEvals(ida_mem::Ptr{Void},nrevals::Ptr{Clong})
+    ccall((:IDAGetNumResEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nrevals)
+end
+
+function IDAGetNumLinSolvSetups(ida_mem::Ptr{Void},nlinsetups::Ptr{Clong})
+    ccall((:IDAGetNumLinSolvSetups,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nlinsetups)
+end
+
+function IDAGetNumErrTestFails(ida_mem::Ptr{Void},netfails::Ptr{Clong})
+    ccall((:IDAGetNumErrTestFails,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,netfails)
+end
+
+function IDAGetNumBacktrackOps(ida_mem::Ptr{Void},nbacktr::Ptr{Clong})
+    ccall((:IDAGetNumBacktrackOps,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nbacktr)
+end
+
+function IDAGetConsistentIC(ida_mem::Ptr{Void},yy0_mod::N_Vector,yp0_mod::N_Vector)
+    ccall((:IDAGetConsistentIC,libsundials_ida),Cint,(Ptr{Void},N_Vector,N_Vector),ida_mem,yy0_mod,yp0_mod)
+end
+
+function IDAGetLastOrder(ida_mem::Ptr{Void},klast::Ptr{Cint})
+    ccall((:IDAGetLastOrder,libsundials_ida),Cint,(Ptr{Void},Ptr{Cint}),ida_mem,klast)
+end
+
+function IDAGetCurrentOrder(ida_mem::Ptr{Void},kcur::Ptr{Cint})
+    ccall((:IDAGetCurrentOrder,libsundials_ida),Cint,(Ptr{Void},Ptr{Cint}),ida_mem,kcur)
+end
+
+function IDAGetActualInitStep(ida_mem::Ptr{Void},hinused::Vector{realtype})
+    ccall((:IDAGetActualInitStep,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype}),ida_mem,hinused)
+end
+
+function IDAGetLastStep(ida_mem::Ptr{Void},hlast::Vector{realtype})
+    ccall((:IDAGetLastStep,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype}),ida_mem,hlast)
+end
+
+function IDAGetCurrentStep(ida_mem::Ptr{Void},hcur::Vector{realtype})
+    ccall((:IDAGetCurrentStep,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype}),ida_mem,hcur)
+end
+
+function IDAGetCurrentTime(ida_mem::Ptr{Void},tcur::Vector{realtype})
+    ccall((:IDAGetCurrentTime,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype}),ida_mem,tcur)
+end
+
+function IDAGetTolScaleFactor(ida_mem::Ptr{Void},tolsfact::Vector{realtype})
+    ccall((:IDAGetTolScaleFactor,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype}),ida_mem,tolsfact)
+end
+
+function IDAGetErrWeights(ida_mem::Ptr{Void},eweight::N_Vector)
+    ccall((:IDAGetErrWeights,libsundials_ida),Cint,(Ptr{Void},N_Vector),ida_mem,eweight)
+end
+
+function IDAGetEstLocalErrors(ida_mem::Ptr{Void},ele::N_Vector)
+    ccall((:IDAGetEstLocalErrors,libsundials_ida),Cint,(Ptr{Void},N_Vector),ida_mem,ele)
+end
+
+function IDAGetNumGEvals(ida_mem::Ptr{Void},ngevals::Ptr{Clong})
+    ccall((:IDAGetNumGEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,ngevals)
+end
+
+function IDAGetRootInfo(ida_mem::Ptr{Void},rootsfound::Ptr{Cint})
+    ccall((:IDAGetRootInfo,libsundials_ida),Cint,(Ptr{Void},Ptr{Cint}),ida_mem,rootsfound)
+end
+
+function IDAGetIntegratorStats(ida_mem::Ptr{Void},nsteps::Ptr{Clong},nrevals::Ptr{Clong},nlinsetups::Ptr{Clong},netfails::Ptr{Clong},qlast::Ptr{Cint},qcur::Ptr{Cint},hinused::Vector{realtype},hlast::Vector{realtype},hcur::Vector{realtype},tcur::Vector{realtype})
+    ccall((:IDAGetIntegratorStats,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Cint},Ptr{Cint},Ptr{realtype},Ptr{realtype},Ptr{realtype},Ptr{realtype}),ida_mem,nsteps,nrevals,nlinsetups,netfails,qlast,qcur,hinused,hlast,hcur,tcur)
+end
+
+function IDAGetNumNonlinSolvIters(ida_mem::Ptr{Void},nniters::Ptr{Clong})
+    ccall((:IDAGetNumNonlinSolvIters,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nniters)
+end
+
+function IDAGetNumNonlinSolvConvFails(ida_mem::Ptr{Void},nncfails::Ptr{Clong})
+    ccall((:IDAGetNumNonlinSolvConvFails,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nncfails)
+end
+
+function IDAGetNonlinSolvStats(ida_mem::Ptr{Void},nniters::Ptr{Clong},nncfails::Ptr{Clong})
+    ccall((:IDAGetNonlinSolvStats,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),ida_mem,nniters,nncfails)
+end
+
+function IDAGetReturnFlagName(flag::Int)
+    ccall((:IDAGetReturnFlagName,libsundials_ida),Ptr{UInt8},(Clong,),flag)
+end
+
+function IDAFree(ida_mem::Vector{Ptr{Void}})
+    ccall((:IDAFree,libsundials_ida),Void,(Ptr{Ptr{Void}},),ida_mem)
+end
+
+function IDAEwtSet(ycur::N_Vector,weight::N_Vector,data::Ptr{Void})
+    ccall((:IDAEwtSet,libsundials_ida),Cint,(N_Vector,N_Vector,Ptr{Void}),ycur,weight,data)
+end
+
+function IDAErrHandler(error_code::Int,_module::Ptr{UInt8},_function::Ptr{UInt8},msg::Ptr{UInt8},data::Ptr{Void})
+    ccall((:IDAErrHandler,libsundials_ida),Void,(Cint,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},Ptr{Void}),error_code,_module,_function,msg,data)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/ida/ida_spbcgs.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function SpbcgMalloc(l_max::Int,vec_tmpl::N_Vector)
+    ccall((:SpbcgMalloc,libsundials_ida),SpbcgMem,(Cint,N_Vector),l_max,vec_tmpl)
+end
+
+function SpbcgSolve(mem::SpbcgMem,A_data::Ptr{Void},x::N_Vector,b::N_Vector,pretype::Int,delta::realtype,P_data::Ptr{Void},sx::N_Vector,sb::N_Vector,atimes::ATimesFn,psolve::PSolveFn,res_norm::Vector{realtype},nli::Ptr{Cint},nps::Ptr{Cint})
+    ccall((:SpbcgSolve,libsundials_ida),Cint,(SpbcgMem,Ptr{Void},N_Vector,N_Vector,Cint,realtype,Ptr{Void},N_Vector,N_Vector,ATimesFn,PSolveFn,Ptr{realtype},Ptr{Cint},Ptr{Cint}),mem,A_data,x,b,pretype,delta,P_data,sx,sb,atimes,psolve,res_norm,nli,nps)
+end
+
+function SpbcgFree(mem::SpbcgMem)
+    ccall((:SpbcgFree,libsundials_ida),Void,(SpbcgMem,),mem)
+end
+
+function IDASpbcg(ida_mem::Ptr{Void},maxl::Int)
+    ccall((:IDASpbcg,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxl)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/ida/ida_spgmr.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function SpgmrMalloc(l_max::Int,vec_tmpl::N_Vector)
+    ccall((:SpgmrMalloc,libsundials_ida),SpgmrMem,(Cint,N_Vector),l_max,vec_tmpl)
+end
+
+function SpgmrSolve(mem::SpgmrMem,A_data::Ptr{Void},x::N_Vector,b::N_Vector,pretype::Int,gstype::Int,delta::realtype,max_restarts::Int,P_data::Ptr{Void},s1::N_Vector,s2::N_Vector,atimes::ATimesFn,psolve::PSolveFn,res_norm::Vector{realtype},nli::Ptr{Cint},nps::Ptr{Cint})
+    ccall((:SpgmrSolve,libsundials_ida),Cint,(SpgmrMem,Ptr{Void},N_Vector,N_Vector,Cint,Cint,realtype,Cint,Ptr{Void},N_Vector,N_Vector,ATimesFn,PSolveFn,Ptr{realtype},Ptr{Cint},Ptr{Cint}),mem,A_data,x,b,pretype,gstype,delta,max_restarts,P_data,s1,s2,atimes,psolve,res_norm,nli,nps)
+end
+
+function SpgmrFree(mem::SpgmrMem)
+    ccall((:SpgmrFree,libsundials_ida),Void,(SpgmrMem,),mem)
+end
+
+function IDASpgmr(ida_mem::Ptr{Void},maxl::Int)
+    ccall((:IDASpgmr,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxl)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/ida/ida_sptfqmr.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function SptfqmrMalloc(l_max::Int,vec_tmpl::N_Vector)
+    ccall((:SptfqmrMalloc,libsundials_ida),SptfqmrMem,(Cint,N_Vector),l_max,vec_tmpl)
+end
+
+function SptfqmrSolve(mem::SptfqmrMem,A_data::Ptr{Void},x::N_Vector,b::N_Vector,pretype::Int,delta::realtype,P_data::Ptr{Void},sx::N_Vector,sb::N_Vector,atimes::ATimesFn,psolve::PSolveFn,res_norm::Vector{realtype},nli::Ptr{Cint},nps::Ptr{Cint})
+    ccall((:SptfqmrSolve,libsundials_ida),Cint,(SptfqmrMem,Ptr{Void},N_Vector,N_Vector,Cint,realtype,Ptr{Void},N_Vector,N_Vector,ATimesFn,PSolveFn,Ptr{realtype},Ptr{Cint},Ptr{Cint}),mem,A_data,x,b,pretype,delta,P_data,sx,sb,atimes,psolve,res_norm,nli,nps)
+end
+
+function SptfqmrFree(mem::SptfqmrMem)
+    ccall((:SptfqmrFree,libsundials_ida),Void,(SptfqmrMem,),mem)
+end
+
+function IDASptfqmr(ida_mem::Ptr{Void},maxl::Int)
+    ccall((:IDASptfqmr,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxl)
+end

--- a/src/idas.jl
+++ b/src/idas.jl
@@ -1,167 +1,1418 @@
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/idas/idas.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
 
-recurs_sym_type(ex::Any) = 
-  (ex==None || typeof(ex)==Symbol || length(ex.args)==1) ? eval(ex) : Expr(ex.head, ex.args[1], recurs_sym_type(ex.args[2]))
-macro c(ret_type, func, arg_types, lib)
-  local _arg_types = Expr(:tuple, [recurs_sym_type(a) for a in arg_types.args]...)
-  local _ret_type = recurs_sym_type(ret_type)
-  local _args_in = Any[ symbol(string('a',x)) for x in 1:length(_arg_types.args) ]
-  local _lib = eval(lib)
-  quote
-    $(esc(func))($(_args_in...)) = ccall( ($(string(func)), $(Expr(:quote, _lib)) ), $_ret_type, $_arg_types, $(_args_in...) )
-  end
+function IDACreate()
+    ccall((:IDACreate,libsundials_ida),Ptr{Void},())
 end
 
-macro ctypedef(fake_t,real_t)
-  real_t = recurs_sym_type(real_t)
-  quote
-    typealias $fake_t $real_t
-  end
+function IDASetErrHandlerFn(ida_mem::Ptr{Void},ehfun::IDAErrHandlerFn,eh_data::Ptr{Void})
+    ccall((:IDASetErrHandlerFn,libsundials_ida),Cint,(Ptr{Void},IDAErrHandlerFn,Ptr{Void}),ida_mem,ehfun,eh_data)
 end
 
-# header: /usr/local/include/idas/idas_band.h
-@ctypedef IDADlsDenseJacFnB Ptr{:Void}
-@ctypedef IDADlsBandJacFnB Ptr{:Void}
-@c Int32 IDADlsSetDenseJacFnB (Ptr{:None},:Int32,:IDADlsDenseJacFnB) shlib
-@c Int32 IDADlsSetBandJacFnB (Ptr{:None},:Int32,:IDADlsBandJacFnB) shlib
-@c Int32 IDABandB (Ptr{:None},:Int32,:Clong,:Clong,:Clong) shlib
+function IDASetErrFile(ida_mem::Ptr{Void},errfp::Ptr{Void})
+    ccall((:IDASetErrFile,libsundials_ida),Cint,(Ptr{Void},Ptr{Void}),ida_mem,errfp)
+end
 
-# header: /usr/local/include/idas/idas_bbdpre.h
-@ctypedef IDABBDLocalFnB Ptr{:Void}
-@ctypedef IDABBDCommFnB Ptr{:Void}
-@c Int32 IDABBDPrecInitB (Ptr{:None},:Int32,:Clong,:Clong,:Clong,:Clong,:Clong,:realtype,:IDABBDLocalFnB,:IDABBDCommFnB) shlib
-@c Int32 IDABBDPrecReInitB (Ptr{:None},:Int32,:Clong,:Clong,:realtype) shlib
+function IDASetUserData(ida_mem::Ptr{Void},user_data::Ptr{Void})
+    ccall((:IDASetUserData,libsundials_ida),Cint,(Ptr{Void},Ptr{Void}),ida_mem,user_data)
+end
 
-# header: /usr/local/include/idas/idas_dense.h
-@c Int32 IDADenseB (Ptr{:None},:Int32,:Clong) shlib
+function IDASetMaxOrd(ida_mem::Ptr{Void},maxord::Int)
+    ccall((:IDASetMaxOrd,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxord)
+end
 
-# header: /usr/local/include/idas/idas_direct.h
+function IDASetMaxNumSteps(ida_mem::Ptr{Void},mxsteps::Int)
+    ccall((:IDASetMaxNumSteps,libsundials_ida),Cint,(Ptr{Void},Clong),ida_mem,mxsteps)
+end
 
-# header: /usr/local/include/idas/idas.h
-@ctypedef IDAQuadRhsFn Ptr{:Void}
-@ctypedef IDASensResFn Ptr{:Void}
-@ctypedef IDAQuadSensRhsFn Ptr{:Void}
-@ctypedef IDAResFnB Ptr{:Void}
-@ctypedef IDAResFnBS Ptr{:Void}
-@ctypedef IDAQuadRhsFnB Ptr{:Void}
-@ctypedef IDAQuadRhsFnBS Ptr{:Void}
-@c Int32 IDASetQuadErrCon (Ptr{:None},:Int32) shlib
-@c Int32 IDAQuadInit (Ptr{:None},:IDAQuadRhsFn,:N_Vector) shlib
-@c Int32 IDAQuadReInit (Ptr{:None},:N_Vector) shlib
-@c Int32 IDAQuadSStolerances (Ptr{:None},:realtype,:realtype) shlib
-@c Int32 IDAQuadSVtolerances (Ptr{:None},:realtype,:N_Vector) shlib
-@c Int32 IDASetSensDQMethod (Ptr{:None},:Int32,:realtype) shlib
-@c Int32 IDASetSensParams (Ptr{:None},Ptr{:realtype},Ptr{:realtype},Ptr{:Int32}) shlib
-@c Int32 IDASetSensErrCon (Ptr{:None},:Int32) shlib
-@c Int32 IDASetSensMaxNonlinIters (Ptr{:None},:Int32) shlib
-@c Int32 IDASensInit (Ptr{:None},:Int32,:Int32,:IDASensResFn,Ptr{:N_Vector},Ptr{:N_Vector}) shlib
-@c Int32 IDASensReInit (Ptr{:None},:Int32,Ptr{:N_Vector},Ptr{:N_Vector}) shlib
-@c Int32 IDASensToggleOff (Ptr{:None},) shlib
-@c Int32 IDASensSStolerances (Ptr{:None},:realtype,Ptr{:realtype}) shlib
-@c Int32 IDASensSVtolerances (Ptr{:None},:realtype,Ptr{:N_Vector}) shlib
-@c Int32 IDASensEEtolerances (Ptr{:None},) shlib
-@c Int32 IDAQuadSensInit (Ptr{:None},:IDAQuadSensRhsFn,Ptr{:N_Vector}) shlib
-@c Int32 IDAQuadSensReInit (Ptr{:None},Ptr{:N_Vector}) shlib
-@c Int32 IDAQuadSensSStolerances (Ptr{:None},:realtype,Ptr{:realtype}) shlib
-@c Int32 IDAQuadSensSVtolerances (Ptr{:None},:realtype,Ptr{:N_Vector}) shlib
-@c Int32 IDAQuadSensEEtolerances (Ptr{:None},) shlib
-@c Int32 IDASetQuadSensErrCon (Ptr{:None},:Int32) shlib
-@c Int32 IDAGetQuad (Ptr{:None},Ptr{:realtype},:N_Vector) shlib
-@c Int32 IDAGetQuadDky (Ptr{:None},:realtype,:Int32,:N_Vector) shlib
-@c Int32 IDAGetQuadNumRhsEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetQuadNumErrTestFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetQuadErrWeights (Ptr{:None},:N_Vector) shlib
-@c Int32 IDAGetQuadStats (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 IDAGetSens (Ptr{:None},Ptr{:realtype},Ptr{:N_Vector}) shlib
-@c Int32 IDAGetSens1 (Ptr{:None},Ptr{:realtype},:Int32,:N_Vector) shlib
-@c Int32 IDAGetSensDky (Ptr{:None},:realtype,:Int32,Ptr{:N_Vector}) shlib
-@c Int32 IDAGetSensDky1 (Ptr{:None},:realtype,:Int32,:Int32,:N_Vector) shlib
-@c Int32 IDAGetSensConsistentIC (Ptr{:None},Ptr{:N_Vector},Ptr{:N_Vector}) shlib
-@c Int32 IDAGetSensNumResEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetNumResEvalsSens (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetSensNumErrTestFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetSensNumLinSolvSetups (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetSensErrWeights (Ptr{:None},:N_Vector_S) shlib
-@c Int32 IDAGetSensStats (Ptr{:None},Ptr{:Clong},Ptr{:Clong},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 IDAGetSensNumNonlinSolvIters (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetSensNumNonlinSolvConvFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetSensNonlinSolvStats (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 IDAGetQuadSensNumRhsEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetQuadSensNumErrTestFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetQuadSensErrWeights (Ptr{:None},Ptr{:N_Vector}) shlib
-@c Int32 IDAGetQuadSensStats (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 IDAGetQuadSens (Ptr{:None},Ptr{:realtype},Ptr{:N_Vector}) shlib
-@c Int32 IDAGetQuadSens1 (Ptr{:None},Ptr{:realtype},:Int32,:N_Vector) shlib
-@c Int32 IDAGetQuadSensDky (Ptr{:None},:realtype,:Int32,Ptr{:N_Vector}) shlib
-@c Int32 IDAGetQuadSensDky1 (Ptr{:None},:realtype,:Int32,:Int32,:N_Vector) shlib
-@c None IDAQuadFree (Ptr{:None},) shlib
-@c None IDASensFree (Ptr{:None},) shlib
-@c None IDAQuadSensFree (Ptr{:None},) shlib
-@c Int32 IDAAdjInit (Ptr{:None},:Clong,:Int32) shlib
-@c Int32 IDAAdjReInit (Ptr{:None},) shlib
-@c None IDAAdjFree (Ptr{:None},) shlib
-@c Int32 IDACreateB (Ptr{:None},Ptr{:Int32}) shlib
-@c Int32 IDAInitB (Ptr{:None},:Int32,:IDAResFnB,:realtype,:N_Vector,:N_Vector) shlib
-@c Int32 IDAInitBS (Ptr{:None},:Int32,:IDAResFnBS,:realtype,:N_Vector,:N_Vector) shlib
-@c Int32 IDAReInitB (Ptr{:None},:Int32,:realtype,:N_Vector,:N_Vector) shlib
-@c Int32 IDASStolerancesB (Ptr{:None},:Int32,:realtype,:realtype) shlib
-@c Int32 IDASVtolerancesB (Ptr{:None},:Int32,:realtype,:N_Vector) shlib
-@c Int32 IDAQuadInitB (Ptr{:None},:Int32,:IDAQuadRhsFnB,:N_Vector) shlib
-@c Int32 IDAQuadInitBS (Ptr{:None},:Int32,:IDAQuadRhsFnBS,:N_Vector) shlib
-@c Int32 IDAQuadReInitB (Ptr{:None},:Int32,:N_Vector) shlib
-@c Int32 IDAQuadSStolerancesB (Ptr{:None},:Int32,:realtype,:realtype) shlib
-@c Int32 IDAQuadSVtolerancesB (Ptr{:None},:Int32,:realtype,:N_Vector) shlib
-@c Int32 IDACalcICB (Ptr{:None},:Int32,:realtype,:N_Vector,:N_Vector) shlib
-@c Int32 IDACalcICBS (Ptr{:None},:Int32,:realtype,:N_Vector,:N_Vector,Ptr{:N_Vector},Ptr{:N_Vector}) shlib
-@c Int32 IDASolveF (Ptr{:None},:realtype,Ptr{:realtype},:N_Vector,:N_Vector,:Int32,Ptr{:Int32}) shlib
-@c Int32 IDASolveB (Ptr{:None},:realtype,:Int32) shlib
-@c Int32 IDASetAdjNoSensi (Ptr{:None},) shlib
-@c Int32 IDASetUserDataB (Ptr{:None},:Int32,Ptr{:None}) shlib
-@c Int32 IDASetMaxOrdB (Ptr{:None},:Int32,:Int32) shlib
-@c Int32 IDASetMaxNumStepsB (Ptr{:None},:Int32,:Clong) shlib
-@c Int32 IDASetInitStepB (Ptr{:None},:Int32,:realtype) shlib
-@c Int32 IDASetMaxStepB (Ptr{:None},:Int32,:realtype) shlib
-@c Int32 IDASetSuppressAlgB (Ptr{:None},:Int32,:Int32) shlib
-@c Int32 IDASetIdB (Ptr{:None},:Int32,:N_Vector) shlib
-@c Int32 IDASetConstraintsB (Ptr{:None},:Int32,:N_Vector) shlib
-@c Int32 IDASetQuadErrConB (Ptr{:None},:Int32,:Int32) shlib
-@c Int32 IDAGetB (Ptr{:None},:Int32,Ptr{:realtype},:N_Vector,:N_Vector) shlib
-@c Int32 IDAGetQuadB (Ptr{:None},:Int32,Ptr{:realtype},:N_Vector) shlib
-@c Ptr{:None} IDAGetAdjIDABmem (Ptr{:None},:Int32) shlib
-@c Int32 IDAGetConsistentICB (Ptr{:None},:Int32,:N_Vector,:N_Vector) shlib
-@c Int32 IDAGetAdjY (Ptr{:None},:realtype,:N_Vector,:N_Vector) shlib
-@ctypedef IDAadjCheckPointRec Void
-@c Int32 IDAGetAdjCheckPointsInfo (Ptr{:None},Ptr{:IDAadjCheckPointRec}) shlib
-@c Int32 IDAGetAdjDataPointHermite (Ptr{:None},:Int32,Ptr{:realtype},:N_Vector,:N_Vector) shlib
-@c Int32 IDAGetAdjDataPointPolynomial (Ptr{:None},:Int32,Ptr{:realtype},Ptr{:Int32},:N_Vector) shlib
-@c Int32 IDAGetAdjCurrentCheckPoint (Ptr{:None},Ptr{Ptr{:None}}) shlib
+function IDASetInitStep(ida_mem::Ptr{Void},hin::realtype)
+    ccall((:IDASetInitStep,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,hin)
+end
 
-# header: /usr/local/include/idas/idas_impl.h
-@ctypedef IDAadjMem Ptr{:Void}
-@ctypedef IDABMem Ptr{:Void}
-@ctypedef IDAAMMallocFn Ptr{:Void}
-@ctypedef IDAAMFreeFn Ptr{:Void}
-@ctypedef IDAAGetYFn Ptr{:Void}
-@ctypedef IDAAStorePntFn Ptr{:Void}
-@c Int32 IDASensResDQ (:Int32,:realtype,:N_Vector,:N_Vector,:N_Vector,Ptr{:N_Vector},Ptr{:N_Vector},Ptr{:N_Vector},Ptr{:None},:N_Vector,:N_Vector,:N_Vector) shlib
+function IDASetMaxStep(ida_mem::Ptr{Void},hmax::realtype)
+    ccall((:IDASetMaxStep,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,hmax)
+end
 
-# header: /usr/local/include/idas/idas_spbcgs.h
-@ctypedef IDASpilsPrecSetupFnB Ptr{:Void}
-@ctypedef IDASpilsPrecSolveFnB Ptr{:Void}
-@ctypedef IDASpilsJacTimesVecFnB Ptr{:Void}
-@c Int32 IDASpilsSetGSTypeB (Ptr{:None},:Int32,:Int32) shlib
-@c Int32 IDASpilsSetMaxRestartsB (Ptr{:None},:Int32,:Int32) shlib
-@c Int32 IDASpilsSetEpsLinB (Ptr{:None},:Int32,:realtype) shlib
-@c Int32 IDASpilsSetMaxlB (Ptr{:None},:Int32,:Int32) shlib
-@c Int32 IDASpilsSetIncrementFactorB (Ptr{:None},:Int32,:realtype) shlib
-@c Int32 IDASpilsSetPreconditionerB (Ptr{:None},:Int32,:IDASpilsPrecSetupFnB,:IDASpilsPrecSolveFnB) shlib
-@c Int32 IDASpilsSetJacTimesVecFnB (Ptr{:None},:Int32,:IDASpilsJacTimesVecFnB) shlib
-@c Int32 IDASpbcgB (Ptr{:None},:Int32,:Int32) shlib
+function IDASetStopTime(ida_mem::Ptr{Void},tstop::realtype)
+    ccall((:IDASetStopTime,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,tstop)
+end
 
-# header: /usr/local/include/idas/idas_spgmr.h
-@c Int32 IDASpgmrB (Ptr{:None},:Int32,:Int32) shlib
+function IDASetNonlinConvCoef(ida_mem::Ptr{Void},epcon::realtype)
+    ccall((:IDASetNonlinConvCoef,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,epcon)
+end
 
-# header: /usr/local/include/idas/idas_spils.h
+function IDASetMaxErrTestFails(ida_mem::Ptr{Void},maxnef::Int)
+    ccall((:IDASetMaxErrTestFails,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxnef)
+end
 
-# header: /usr/local/include/idas/idas_sptfqmr.h
-@c Int32 IDASptfqmrB (Ptr{:None},:Int32,:Int32) shlib
+function IDASetMaxNonlinIters(ida_mem::Ptr{Void},maxcor::Int)
+    ccall((:IDASetMaxNonlinIters,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxcor)
+end
 
+function IDASetMaxConvFails(ida_mem::Ptr{Void},maxncf::Int)
+    ccall((:IDASetMaxConvFails,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxncf)
+end
+
+function IDASetSuppressAlg(ida_mem::Ptr{Void},suppressalg::Int)
+    ccall((:IDASetSuppressAlg,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,suppressalg)
+end
+
+function IDASetId(ida_mem::Ptr{Void},id::N_Vector)
+    ccall((:IDASetId,libsundials_ida),Cint,(Ptr{Void},N_Vector),ida_mem,id)
+end
+
+function IDASetConstraints(ida_mem::Ptr{Void},constraints::N_Vector)
+    ccall((:IDASetConstraints,libsundials_ida),Cint,(Ptr{Void},N_Vector),ida_mem,constraints)
+end
+
+function IDASetRootDirection(ida_mem::Ptr{Void},rootdir::Ptr{Cint})
+    ccall((:IDASetRootDirection,libsundials_ida),Cint,(Ptr{Void},Ptr{Cint}),ida_mem,rootdir)
+end
+
+function IDASetNoInactiveRootWarn(ida_mem::Ptr{Void})
+    ccall((:IDASetNoInactiveRootWarn,libsundials_ida),Cint,(Ptr{Void},),ida_mem)
+end
+
+function IDAInit(ida_mem::Ptr{Void},res::IDAResFn,t0::realtype,yy0::N_Vector,yp0::N_Vector)
+    ccall((:IDAInit,libsundials_ida),Cint,(Ptr{Void},IDAResFn,realtype,N_Vector,N_Vector),ida_mem,res,t0,yy0,yp0)
+end
+
+function IDAReInit(ida_mem::Ptr{Void},t0::realtype,yy0::N_Vector,yp0::N_Vector)
+    ccall((:IDAReInit,libsundials_ida),Cint,(Ptr{Void},realtype,N_Vector,N_Vector),ida_mem,t0,yy0,yp0)
+end
+
+function IDASStolerances(ida_mem::Ptr{Void},reltol::realtype,abstol::realtype)
+    ccall((:IDASStolerances,libsundials_ida),Cint,(Ptr{Void},realtype,realtype),ida_mem,reltol,abstol)
+end
+
+function IDASVtolerances(ida_mem::Ptr{Void},reltol::realtype,abstol::N_Vector)
+    ccall((:IDASVtolerances,libsundials_ida),Cint,(Ptr{Void},realtype,N_Vector),ida_mem,reltol,abstol)
+end
+
+function IDAWFtolerances(ida_mem::Ptr{Void},efun::IDAEwtFn)
+    ccall((:IDAWFtolerances,libsundials_ida),Cint,(Ptr{Void},IDAEwtFn),ida_mem,efun)
+end
+
+function IDASetNonlinConvCoefIC(ida_mem::Ptr{Void},epiccon::realtype)
+    ccall((:IDASetNonlinConvCoefIC,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,epiccon)
+end
+
+function IDASetMaxNumStepsIC(ida_mem::Ptr{Void},maxnh::Int)
+    ccall((:IDASetMaxNumStepsIC,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxnh)
+end
+
+function IDASetMaxNumJacsIC(ida_mem::Ptr{Void},maxnj::Int)
+    ccall((:IDASetMaxNumJacsIC,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxnj)
+end
+
+function IDASetMaxNumItersIC(ida_mem::Ptr{Void},maxnit::Int)
+    ccall((:IDASetMaxNumItersIC,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxnit)
+end
+
+function IDASetLineSearchOffIC(ida_mem::Ptr{Void},lsoff::Int)
+    ccall((:IDASetLineSearchOffIC,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,lsoff)
+end
+
+function IDASetStepToleranceIC(ida_mem::Ptr{Void},steptol::realtype)
+    ccall((:IDASetStepToleranceIC,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,steptol)
+end
+
+function IDARootInit(ida_mem::Ptr{Void},nrtfn::Int,g::IDARootFn)
+    ccall((:IDARootInit,libsundials_ida),Cint,(Ptr{Void},Cint,IDARootFn),ida_mem,nrtfn,g)
+end
+
+function IDASetQuadErrCon(ida_mem::Ptr{Void},errconQ::Int)
+    ccall((:IDASetQuadErrCon,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,errconQ)
+end
+
+function IDAQuadInit(ida_mem::Ptr{Void},rhsQ::IDAQuadRhsFn,yQ0::N_Vector)
+    ccall((:IDAQuadInit,libsundials_ida),Cint,(Ptr{Void},IDAQuadRhsFn,N_Vector),ida_mem,rhsQ,yQ0)
+end
+
+function IDAQuadReInit(ida_mem::Ptr{Void},yQ0::N_Vector)
+    ccall((:IDAQuadReInit,libsundials_ida),Cint,(Ptr{Void},N_Vector),ida_mem,yQ0)
+end
+
+function IDAQuadSStolerances(ida_mem::Ptr{Void},reltolQ::realtype,abstolQ::realtype)
+    ccall((:IDAQuadSStolerances,libsundials_ida),Cint,(Ptr{Void},realtype,realtype),ida_mem,reltolQ,abstolQ)
+end
+
+function IDAQuadSVtolerances(ida_mem::Ptr{Void},reltolQ::realtype,abstolQ::N_Vector)
+    ccall((:IDAQuadSVtolerances,libsundials_ida),Cint,(Ptr{Void},realtype,N_Vector),ida_mem,reltolQ,abstolQ)
+end
+
+function IDASetSensDQMethod(ida_mem::Ptr{Void},DQtype::Int,DQrhomax::realtype)
+    ccall((:IDASetSensDQMethod,libsundials_ida),Cint,(Ptr{Void},Cint,realtype),ida_mem,DQtype,DQrhomax)
+end
+
+function IDASetSensParams(ida_mem::Ptr{Void},p::Vector{realtype},pbar::Vector{realtype},plist::Ptr{Cint})
+    ccall((:IDASetSensParams,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype},Ptr{realtype},Ptr{Cint}),ida_mem,p,pbar,plist)
+end
+
+function IDASetSensErrCon(ida_mem::Ptr{Void},errconS::Int)
+    ccall((:IDASetSensErrCon,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,errconS)
+end
+
+function IDASetSensMaxNonlinIters(ida_mem::Ptr{Void},maxcorS::Int)
+    ccall((:IDASetSensMaxNonlinIters,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxcorS)
+end
+
+function IDASensInit(ida_mem::Ptr{Void},Ns::Int,ism::Int,resS::IDASensResFn,yS0::Ptr{N_Vector},ypS0::Ptr{N_Vector})
+    ccall((:IDASensInit,libsundials_ida),Cint,(Ptr{Void},Cint,Cint,IDASensResFn,Ptr{N_Vector},Ptr{N_Vector}),ida_mem,Ns,ism,resS,yS0,ypS0)
+end
+
+function IDASensReInit(ida_mem::Ptr{Void},ism::Int,yS0::Ptr{N_Vector},ypS0::Ptr{N_Vector})
+    ccall((:IDASensReInit,libsundials_ida),Cint,(Ptr{Void},Cint,Ptr{N_Vector},Ptr{N_Vector}),ida_mem,ism,yS0,ypS0)
+end
+
+function IDASensToggleOff(ida_mem::Ptr{Void})
+    ccall((:IDASensToggleOff,libsundials_ida),Cint,(Ptr{Void},),ida_mem)
+end
+
+function IDASensSStolerances(ida_mem::Ptr{Void},reltolS::realtype,abstolS::Vector{realtype})
+    ccall((:IDASensSStolerances,libsundials_ida),Cint,(Ptr{Void},realtype,Ptr{realtype}),ida_mem,reltolS,abstolS)
+end
+
+function IDASensSVtolerances(ida_mem::Ptr{Void},reltolS::realtype,abstolS::Ptr{N_Vector})
+    ccall((:IDASensSVtolerances,libsundials_ida),Cint,(Ptr{Void},realtype,Ptr{N_Vector}),ida_mem,reltolS,abstolS)
+end
+
+function IDASensEEtolerances(ida_mem::Ptr{Void})
+    ccall((:IDASensEEtolerances,libsundials_ida),Cint,(Ptr{Void},),ida_mem)
+end
+
+function IDAQuadSensInit(ida_mem::Ptr{Void},resQS::IDAQuadSensRhsFn,yQS0::Ptr{N_Vector})
+    ccall((:IDAQuadSensInit,libsundials_ida),Cint,(Ptr{Void},IDAQuadSensRhsFn,Ptr{N_Vector}),ida_mem,resQS,yQS0)
+end
+
+function IDAQuadSensReInit(ida_mem::Ptr{Void},yQS0::Ptr{N_Vector})
+    ccall((:IDAQuadSensReInit,libsundials_ida),Cint,(Ptr{Void},Ptr{N_Vector}),ida_mem,yQS0)
+end
+
+function IDAQuadSensSStolerances(ida_mem::Ptr{Void},reltolQS::realtype,abstolQS::Vector{realtype})
+    ccall((:IDAQuadSensSStolerances,libsundials_ida),Cint,(Ptr{Void},realtype,Ptr{realtype}),ida_mem,reltolQS,abstolQS)
+end
+
+function IDAQuadSensSVtolerances(ida_mem::Ptr{Void},reltolQS::realtype,abstolQS::Ptr{N_Vector})
+    ccall((:IDAQuadSensSVtolerances,libsundials_ida),Cint,(Ptr{Void},realtype,Ptr{N_Vector}),ida_mem,reltolQS,abstolQS)
+end
+
+function IDAQuadSensEEtolerances(ida_mem::Ptr{Void})
+    ccall((:IDAQuadSensEEtolerances,libsundials_ida),Cint,(Ptr{Void},),ida_mem)
+end
+
+function IDASetQuadSensErrCon(ida_mem::Ptr{Void},errconQS::Int)
+    ccall((:IDASetQuadSensErrCon,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,errconQS)
+end
+
+function IDACalcIC(ida_mem::Ptr{Void},icopt::Int,tout1::realtype)
+    ccall((:IDACalcIC,libsundials_ida),Cint,(Ptr{Void},Cint,realtype),ida_mem,icopt,tout1)
+end
+
+function IDASolve(ida_mem::Ptr{Void},tout::realtype,tret::Vector{realtype},yret::N_Vector,ypret::N_Vector,itask::Int)
+    ccall((:IDASolve,libsundials_ida),Cint,(Ptr{Void},realtype,Ptr{realtype},N_Vector,N_Vector,Cint),ida_mem,tout,tret,yret,ypret,itask)
+end
+
+function IDAGetDky(ida_mem::Ptr{Void},t::realtype,k::Int,dky::N_Vector)
+    ccall((:IDAGetDky,libsundials_ida),Cint,(Ptr{Void},realtype,Cint,N_Vector),ida_mem,t,k,dky)
+end
+
+function IDAGetWorkSpace(ida_mem::Ptr{Void},lenrw::Ptr{Clong},leniw::Ptr{Clong})
+    ccall((:IDAGetWorkSpace,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),ida_mem,lenrw,leniw)
+end
+
+function IDAGetNumSteps(ida_mem::Ptr{Void},nsteps::Ptr{Clong})
+    ccall((:IDAGetNumSteps,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nsteps)
+end
+
+function IDAGetNumResEvals(ida_mem::Ptr{Void},nrevals::Ptr{Clong})
+    ccall((:IDAGetNumResEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nrevals)
+end
+
+function IDAGetNumLinSolvSetups(ida_mem::Ptr{Void},nlinsetups::Ptr{Clong})
+    ccall((:IDAGetNumLinSolvSetups,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nlinsetups)
+end
+
+function IDAGetNumErrTestFails(ida_mem::Ptr{Void},netfails::Ptr{Clong})
+    ccall((:IDAGetNumErrTestFails,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,netfails)
+end
+
+function IDAGetNumBacktrackOps(ida_mem::Ptr{Void},nbacktr::Ptr{Clong})
+    ccall((:IDAGetNumBacktrackOps,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nbacktr)
+end
+
+function IDAGetConsistentIC(ida_mem::Ptr{Void},yy0_mod::N_Vector,yp0_mod::N_Vector)
+    ccall((:IDAGetConsistentIC,libsundials_ida),Cint,(Ptr{Void},N_Vector,N_Vector),ida_mem,yy0_mod,yp0_mod)
+end
+
+function IDAGetLastOrder(ida_mem::Ptr{Void},klast::Ptr{Cint})
+    ccall((:IDAGetLastOrder,libsundials_ida),Cint,(Ptr{Void},Ptr{Cint}),ida_mem,klast)
+end
+
+function IDAGetCurrentOrder(ida_mem::Ptr{Void},kcur::Ptr{Cint})
+    ccall((:IDAGetCurrentOrder,libsundials_ida),Cint,(Ptr{Void},Ptr{Cint}),ida_mem,kcur)
+end
+
+function IDAGetActualInitStep(ida_mem::Ptr{Void},hinused::Vector{realtype})
+    ccall((:IDAGetActualInitStep,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype}),ida_mem,hinused)
+end
+
+function IDAGetLastStep(ida_mem::Ptr{Void},hlast::Vector{realtype})
+    ccall((:IDAGetLastStep,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype}),ida_mem,hlast)
+end
+
+function IDAGetCurrentStep(ida_mem::Ptr{Void},hcur::Vector{realtype})
+    ccall((:IDAGetCurrentStep,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype}),ida_mem,hcur)
+end
+
+function IDAGetCurrentTime(ida_mem::Ptr{Void},tcur::Vector{realtype})
+    ccall((:IDAGetCurrentTime,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype}),ida_mem,tcur)
+end
+
+function IDAGetTolScaleFactor(ida_mem::Ptr{Void},tolsfact::Vector{realtype})
+    ccall((:IDAGetTolScaleFactor,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype}),ida_mem,tolsfact)
+end
+
+function IDAGetErrWeights(ida_mem::Ptr{Void},eweight::N_Vector)
+    ccall((:IDAGetErrWeights,libsundials_ida),Cint,(Ptr{Void},N_Vector),ida_mem,eweight)
+end
+
+function IDAGetEstLocalErrors(ida_mem::Ptr{Void},ele::N_Vector)
+    ccall((:IDAGetEstLocalErrors,libsundials_ida),Cint,(Ptr{Void},N_Vector),ida_mem,ele)
+end
+
+function IDAGetNumGEvals(ida_mem::Ptr{Void},ngevals::Ptr{Clong})
+    ccall((:IDAGetNumGEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,ngevals)
+end
+
+function IDAGetRootInfo(ida_mem::Ptr{Void},rootsfound::Ptr{Cint})
+    ccall((:IDAGetRootInfo,libsundials_ida),Cint,(Ptr{Void},Ptr{Cint}),ida_mem,rootsfound)
+end
+
+function IDAGetIntegratorStats(ida_mem::Ptr{Void},nsteps::Ptr{Clong},nrevals::Ptr{Clong},nlinsetups::Ptr{Clong},netfails::Ptr{Clong},qlast::Ptr{Cint},qcur::Ptr{Cint},hinused::Vector{realtype},hlast::Vector{realtype},hcur::Vector{realtype},tcur::Vector{realtype})
+    ccall((:IDAGetIntegratorStats,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Cint},Ptr{Cint},Ptr{realtype},Ptr{realtype},Ptr{realtype},Ptr{realtype}),ida_mem,nsteps,nrevals,nlinsetups,netfails,qlast,qcur,hinused,hlast,hcur,tcur)
+end
+
+function IDAGetNumNonlinSolvIters(ida_mem::Ptr{Void},nniters::Ptr{Clong})
+    ccall((:IDAGetNumNonlinSolvIters,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nniters)
+end
+
+function IDAGetNumNonlinSolvConvFails(ida_mem::Ptr{Void},nncfails::Ptr{Clong})
+    ccall((:IDAGetNumNonlinSolvConvFails,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nncfails)
+end
+
+function IDAGetNonlinSolvStats(ida_mem::Ptr{Void},nniters::Ptr{Clong},nncfails::Ptr{Clong})
+    ccall((:IDAGetNonlinSolvStats,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),ida_mem,nniters,nncfails)
+end
+
+function IDAGetQuad(ida_mem::Ptr{Void},t::Vector{realtype},yQout::N_Vector)
+    ccall((:IDAGetQuad,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype},N_Vector),ida_mem,t,yQout)
+end
+
+function IDAGetQuadDky(ida_mem::Ptr{Void},t::realtype,k::Int,dky::N_Vector)
+    ccall((:IDAGetQuadDky,libsundials_ida),Cint,(Ptr{Void},realtype,Cint,N_Vector),ida_mem,t,k,dky)
+end
+
+function IDAGetQuadNumRhsEvals(ida_mem::Ptr{Void},nrhsQevals::Ptr{Clong})
+    ccall((:IDAGetQuadNumRhsEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nrhsQevals)
+end
+
+function IDAGetQuadNumErrTestFails(ida_mem::Ptr{Void},nQetfails::Ptr{Clong})
+    ccall((:IDAGetQuadNumErrTestFails,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nQetfails)
+end
+
+function IDAGetQuadErrWeights(ida_mem::Ptr{Void},eQweight::N_Vector)
+    ccall((:IDAGetQuadErrWeights,libsundials_ida),Cint,(Ptr{Void},N_Vector),ida_mem,eQweight)
+end
+
+function IDAGetQuadStats(ida_mem::Ptr{Void},nrhsQevals::Ptr{Clong},nQetfails::Ptr{Clong})
+    ccall((:IDAGetQuadStats,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),ida_mem,nrhsQevals,nQetfails)
+end
+
+function IDAGetSens(ida_mem::Ptr{Void},tret::Vector{realtype},yySout::Ptr{N_Vector})
+    ccall((:IDAGetSens,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype},Ptr{N_Vector}),ida_mem,tret,yySout)
+end
+
+function IDAGetSens1(ida_mem::Ptr{Void},tret::Vector{realtype},is::Int,yySret::N_Vector)
+    ccall((:IDAGetSens1,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype},Cint,N_Vector),ida_mem,tret,is,yySret)
+end
+
+function IDAGetSensDky(ida_mem::Ptr{Void},t::realtype,k::Int,dkyS::Ptr{N_Vector})
+    ccall((:IDAGetSensDky,libsundials_ida),Cint,(Ptr{Void},realtype,Cint,Ptr{N_Vector}),ida_mem,t,k,dkyS)
+end
+
+function IDAGetSensDky1(ida_mem::Ptr{Void},t::realtype,k::Int,is::Int,dkyS::N_Vector)
+    ccall((:IDAGetSensDky1,libsundials_ida),Cint,(Ptr{Void},realtype,Cint,Cint,N_Vector),ida_mem,t,k,is,dkyS)
+end
+
+function IDAGetSensConsistentIC(ida_mem::Ptr{Void},yyS0::Ptr{N_Vector},ypS0::Ptr{N_Vector})
+    ccall((:IDAGetSensConsistentIC,libsundials_ida),Cint,(Ptr{Void},Ptr{N_Vector},Ptr{N_Vector}),ida_mem,yyS0,ypS0)
+end
+
+function IDAGetSensNumResEvals(ida_mem::Ptr{Void},nresSevals::Ptr{Clong})
+    ccall((:IDAGetSensNumResEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nresSevals)
+end
+
+function IDAGetNumResEvalsSens(ida_mem::Ptr{Void},nresevalsS::Ptr{Clong})
+    ccall((:IDAGetNumResEvalsSens,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nresevalsS)
+end
+
+function IDAGetSensNumErrTestFails(ida_mem::Ptr{Void},nSetfails::Ptr{Clong})
+    ccall((:IDAGetSensNumErrTestFails,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nSetfails)
+end
+
+function IDAGetSensNumLinSolvSetups(ida_mem::Ptr{Void},nlinsetupsS::Ptr{Clong})
+    ccall((:IDAGetSensNumLinSolvSetups,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nlinsetupsS)
+end
+
+function IDAGetSensErrWeights(ida_mem::Ptr{Void},eSweight::N_Vector_S)
+    ccall((:IDAGetSensErrWeights,libsundials_ida),Cint,(Ptr{Void},N_Vector_S),ida_mem,eSweight)
+end
+
+function IDAGetSensStats(ida_mem::Ptr{Void},nresSevals::Ptr{Clong},nresevalsS::Ptr{Clong},nSetfails::Ptr{Clong},nlinsetupsS::Ptr{Clong})
+    ccall((:IDAGetSensStats,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Clong}),ida_mem,nresSevals,nresevalsS,nSetfails,nlinsetupsS)
+end
+
+function IDAGetSensNumNonlinSolvIters(ida_mem::Ptr{Void},nSniters::Ptr{Clong})
+    ccall((:IDAGetSensNumNonlinSolvIters,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nSniters)
+end
+
+function IDAGetSensNumNonlinSolvConvFails(ida_mem::Ptr{Void},nSncfails::Ptr{Clong})
+    ccall((:IDAGetSensNumNonlinSolvConvFails,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nSncfails)
+end
+
+function IDAGetSensNonlinSolvStats(ida_mem::Ptr{Void},nSniters::Ptr{Clong},nSncfails::Ptr{Clong})
+    ccall((:IDAGetSensNonlinSolvStats,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),ida_mem,nSniters,nSncfails)
+end
+
+function IDAGetQuadSensNumRhsEvals(ida_mem::Ptr{Void},nrhsQSevals::Ptr{Clong})
+    ccall((:IDAGetQuadSensNumRhsEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nrhsQSevals)
+end
+
+function IDAGetQuadSensNumErrTestFails(ida_mem::Ptr{Void},nQSetfails::Ptr{Clong})
+    ccall((:IDAGetQuadSensNumErrTestFails,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nQSetfails)
+end
+
+function IDAGetQuadSensErrWeights(ida_mem::Ptr{Void},eQSweight::Ptr{N_Vector})
+    ccall((:IDAGetQuadSensErrWeights,libsundials_ida),Cint,(Ptr{Void},Ptr{N_Vector}),ida_mem,eQSweight)
+end
+
+function IDAGetQuadSensStats(ida_mem::Ptr{Void},nrhsQSevals::Ptr{Clong},nQSetfails::Ptr{Clong})
+    ccall((:IDAGetQuadSensStats,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),ida_mem,nrhsQSevals,nQSetfails)
+end
+
+function IDAGetQuadSens(ida_mem::Ptr{Void},tret::Vector{realtype},yyQSout::Ptr{N_Vector})
+    ccall((:IDAGetQuadSens,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype},Ptr{N_Vector}),ida_mem,tret,yyQSout)
+end
+
+function IDAGetQuadSens1(ida_mem::Ptr{Void},tret::Vector{realtype},is::Int,yyQSret::N_Vector)
+    ccall((:IDAGetQuadSens1,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype},Cint,N_Vector),ida_mem,tret,is,yyQSret)
+end
+
+function IDAGetQuadSensDky(ida_mem::Ptr{Void},t::realtype,k::Int,dkyQS::Ptr{N_Vector})
+    ccall((:IDAGetQuadSensDky,libsundials_ida),Cint,(Ptr{Void},realtype,Cint,Ptr{N_Vector}),ida_mem,t,k,dkyQS)
+end
+
+function IDAGetQuadSensDky1(ida_mem::Ptr{Void},t::realtype,k::Int,is::Int,dkyQS::N_Vector)
+    ccall((:IDAGetQuadSensDky1,libsundials_ida),Cint,(Ptr{Void},realtype,Cint,Cint,N_Vector),ida_mem,t,k,is,dkyQS)
+end
+
+function IDAGetReturnFlagName(flag::Int)
+    ccall((:IDAGetReturnFlagName,libsundials_ida),Ptr{UInt8},(Clong,),flag)
+end
+
+function IDAFree(ida_mem::Vector{Ptr{Void}})
+    ccall((:IDAFree,libsundials_ida),Void,(Ptr{Ptr{Void}},),ida_mem)
+end
+
+function IDAQuadFree(ida_mem::Ptr{Void})
+    ccall((:IDAQuadFree,libsundials_ida),Void,(Ptr{Void},),ida_mem)
+end
+
+function IDASensFree(ida_mem::Ptr{Void})
+    ccall((:IDASensFree,libsundials_ida),Void,(Ptr{Void},),ida_mem)
+end
+
+function IDAQuadSensFree(ida_mem::Ptr{Void})
+    ccall((:IDAQuadSensFree,libsundials_ida),Void,(Ptr{Void},),ida_mem)
+end
+
+function IDAAdjInit(ida_mem::Ptr{Void},steps::Int,interp::Int)
+    ccall((:IDAAdjInit,libsundials_ida),Cint,(Ptr{Void},Clong,Cint),ida_mem,steps,interp)
+end
+
+function IDAAdjReInit(ida_mem::Ptr{Void})
+    ccall((:IDAAdjReInit,libsundials_ida),Cint,(Ptr{Void},),ida_mem)
+end
+
+function IDAAdjFree(ida_mem::Ptr{Void})
+    ccall((:IDAAdjFree,libsundials_ida),Void,(Ptr{Void},),ida_mem)
+end
+
+function IDACreateB(ida_mem::Ptr{Void},which::Ptr{Cint})
+    ccall((:IDACreateB,libsundials_ida),Cint,(Ptr{Void},Ptr{Cint}),ida_mem,which)
+end
+
+function IDAInitB(ida_mem::Ptr{Void},which::Int,resB::IDAResFnB,tB0::realtype,yyB0::N_Vector,ypB0::N_Vector)
+    ccall((:IDAInitB,libsundials_ida),Cint,(Ptr{Void},Cint,IDAResFnB,realtype,N_Vector,N_Vector),ida_mem,which,resB,tB0,yyB0,ypB0)
+end
+
+function IDAInitBS(ida_mem::Ptr{Void},which::Int,resS::IDAResFnBS,tB0::realtype,yyB0::N_Vector,ypB0::N_Vector)
+    ccall((:IDAInitBS,libsundials_ida),Cint,(Ptr{Void},Cint,IDAResFnBS,realtype,N_Vector,N_Vector),ida_mem,which,resS,tB0,yyB0,ypB0)
+end
+
+function IDAReInitB(ida_mem::Ptr{Void},which::Int,tB0::realtype,yyB0::N_Vector,ypB0::N_Vector)
+    ccall((:IDAReInitB,libsundials_ida),Cint,(Ptr{Void},Cint,realtype,N_Vector,N_Vector),ida_mem,which,tB0,yyB0,ypB0)
+end
+
+function IDASStolerancesB(ida_mem::Ptr{Void},which::Int,relTolB::realtype,absTolB::realtype)
+    ccall((:IDASStolerancesB,libsundials_ida),Cint,(Ptr{Void},Cint,realtype,realtype),ida_mem,which,relTolB,absTolB)
+end
+
+function IDASVtolerancesB(ida_mem::Ptr{Void},which::Int,relTolB::realtype,absTolB::N_Vector)
+    ccall((:IDASVtolerancesB,libsundials_ida),Cint,(Ptr{Void},Cint,realtype,N_Vector),ida_mem,which,relTolB,absTolB)
+end
+
+function IDAQuadInitB(ida_mem::Ptr{Void},which::Int,rhsQB::IDAQuadRhsFnB,yQB0::N_Vector)
+    ccall((:IDAQuadInitB,libsundials_ida),Cint,(Ptr{Void},Cint,IDAQuadRhsFnB,N_Vector),ida_mem,which,rhsQB,yQB0)
+end
+
+function IDAQuadInitBS(ida_mem::Ptr{Void},which::Int,rhsQS::IDAQuadRhsFnBS,yQB0::N_Vector)
+    ccall((:IDAQuadInitBS,libsundials_ida),Cint,(Ptr{Void},Cint,IDAQuadRhsFnBS,N_Vector),ida_mem,which,rhsQS,yQB0)
+end
+
+function IDAQuadReInitB(ida_mem::Ptr{Void},which::Int,yQB0::N_Vector)
+    ccall((:IDAQuadReInitB,libsundials_ida),Cint,(Ptr{Void},Cint,N_Vector),ida_mem,which,yQB0)
+end
+
+function IDAQuadSStolerancesB(ida_mem::Ptr{Void},which::Int,reltolQB::realtype,abstolQB::realtype)
+    ccall((:IDAQuadSStolerancesB,libsundials_ida),Cint,(Ptr{Void},Cint,realtype,realtype),ida_mem,which,reltolQB,abstolQB)
+end
+
+function IDAQuadSVtolerancesB(ida_mem::Ptr{Void},which::Int,reltolQB::realtype,abstolQB::N_Vector)
+    ccall((:IDAQuadSVtolerancesB,libsundials_ida),Cint,(Ptr{Void},Cint,realtype,N_Vector),ida_mem,which,reltolQB,abstolQB)
+end
+
+function IDACalcICB(ida_mem::Ptr{Void},which::Int,tout1::realtype,yy0::N_Vector,yp0::N_Vector)
+    ccall((:IDACalcICB,libsundials_ida),Cint,(Ptr{Void},Cint,realtype,N_Vector,N_Vector),ida_mem,which,tout1,yy0,yp0)
+end
+
+function IDACalcICBS(ida_mem::Ptr{Void},which::Int,tout1::realtype,yy0::N_Vector,yp0::N_Vector,yyS0::Ptr{N_Vector},ypS0::Ptr{N_Vector})
+    ccall((:IDACalcICBS,libsundials_ida),Cint,(Ptr{Void},Cint,realtype,N_Vector,N_Vector,Ptr{N_Vector},Ptr{N_Vector}),ida_mem,which,tout1,yy0,yp0,yyS0,ypS0)
+end
+
+function IDASolveF(ida_mem::Ptr{Void},tout::realtype,tret::Vector{realtype},yret::N_Vector,ypret::N_Vector,itask::Int,ncheckPtr::Ptr{Cint})
+    ccall((:IDASolveF,libsundials_ida),Cint,(Ptr{Void},realtype,Ptr{realtype},N_Vector,N_Vector,Cint,Ptr{Cint}),ida_mem,tout,tret,yret,ypret,itask,ncheckPtr)
+end
+
+function IDASolveB(ida_mem::Ptr{Void},tBout::realtype,itaskB::Int)
+    ccall((:IDASolveB,libsundials_ida),Cint,(Ptr{Void},realtype,Cint),ida_mem,tBout,itaskB)
+end
+
+function IDASetAdjNoSensi(ida_mem::Ptr{Void})
+    ccall((:IDASetAdjNoSensi,libsundials_ida),Cint,(Ptr{Void},),ida_mem)
+end
+
+function IDASetUserDataB(ida_mem::Ptr{Void},which::Int,user_dataB::Ptr{Void})
+    ccall((:IDASetUserDataB,libsundials_ida),Cint,(Ptr{Void},Cint,Ptr{Void}),ida_mem,which,user_dataB)
+end
+
+function IDASetMaxOrdB(ida_mem::Ptr{Void},which::Int,maxordB::Int)
+    ccall((:IDASetMaxOrdB,libsundials_ida),Cint,(Ptr{Void},Cint,Cint),ida_mem,which,maxordB)
+end
+
+function IDASetMaxNumStepsB(ida_mem::Ptr{Void},which::Int,mxstepsB::Int)
+    ccall((:IDASetMaxNumStepsB,libsundials_ida),Cint,(Ptr{Void},Cint,Clong),ida_mem,which,mxstepsB)
+end
+
+function IDASetInitStepB(ida_mem::Ptr{Void},which::Int,hinB::realtype)
+    ccall((:IDASetInitStepB,libsundials_ida),Cint,(Ptr{Void},Cint,realtype),ida_mem,which,hinB)
+end
+
+function IDASetMaxStepB(ida_mem::Ptr{Void},which::Int,hmaxB::realtype)
+    ccall((:IDASetMaxStepB,libsundials_ida),Cint,(Ptr{Void},Cint,realtype),ida_mem,which,hmaxB)
+end
+
+function IDASetSuppressAlgB(ida_mem::Ptr{Void},which::Int,suppressalgB::Int)
+    ccall((:IDASetSuppressAlgB,libsundials_ida),Cint,(Ptr{Void},Cint,Cint),ida_mem,which,suppressalgB)
+end
+
+function IDASetIdB(ida_mem::Ptr{Void},which::Int,idB::N_Vector)
+    ccall((:IDASetIdB,libsundials_ida),Cint,(Ptr{Void},Cint,N_Vector),ida_mem,which,idB)
+end
+
+function IDASetConstraintsB(ida_mem::Ptr{Void},which::Int,constraintsB::N_Vector)
+    ccall((:IDASetConstraintsB,libsundials_ida),Cint,(Ptr{Void},Cint,N_Vector),ida_mem,which,constraintsB)
+end
+
+function IDASetQuadErrConB(ida_mem::Ptr{Void},which::Int,errconQB::Int)
+    ccall((:IDASetQuadErrConB,libsundials_ida),Cint,(Ptr{Void},Cint,Cint),ida_mem,which,errconQB)
+end
+
+function IDAGetB(ida_mem::Ptr{Void},which::Int,tret::Vector{realtype},yy::N_Vector,yp::N_Vector)
+    ccall((:IDAGetB,libsundials_ida),Cint,(Ptr{Void},Cint,Ptr{realtype},N_Vector,N_Vector),ida_mem,which,tret,yy,yp)
+end
+
+function IDAGetQuadB(ida_mem::Ptr{Void},which::Int,tret::Vector{realtype},qB::N_Vector)
+    ccall((:IDAGetQuadB,libsundials_ida),Cint,(Ptr{Void},Cint,Ptr{realtype},N_Vector),ida_mem,which,tret,qB)
+end
+
+function IDAGetAdjIDABmem(ida_mem::Ptr{Void},which::Int)
+    ccall((:IDAGetAdjIDABmem,libsundials_ida),Ptr{Void},(Ptr{Void},Cint),ida_mem,which)
+end
+
+function IDAGetConsistentICB(ida_mem::Ptr{Void},which::Int,yyB0::N_Vector,ypB0::N_Vector)
+    ccall((:IDAGetConsistentICB,libsundials_ida),Cint,(Ptr{Void},Cint,N_Vector,N_Vector),ida_mem,which,yyB0,ypB0)
+end
+
+function IDAGetAdjY(ida_mem::Ptr{Void},t::realtype,yy::N_Vector,yp::N_Vector)
+    ccall((:IDAGetAdjY,libsundials_ida),Cint,(Ptr{Void},realtype,N_Vector,N_Vector),ida_mem,t,yy,yp)
+end
+
+function IDAGetAdjCheckPointsInfo(ida_mem::Ptr{Void},ckpnt::Ptr{IDAadjCheckPointRec})
+    ccall((:IDAGetAdjCheckPointsInfo,libsundials_ida),Cint,(Ptr{Void},Ptr{IDAadjCheckPointRec}),ida_mem,ckpnt)
+end
+
+function IDAGetAdjDataPointHermite(ida_mem::Ptr{Void},which::Int,t::Vector{realtype},yy::N_Vector,yd::N_Vector)
+    ccall((:IDAGetAdjDataPointHermite,libsundials_ida),Cint,(Ptr{Void},Cint,Ptr{realtype},N_Vector,N_Vector),ida_mem,which,t,yy,yd)
+end
+
+function IDAGetAdjDataPointPolynomial(ida_mem::Ptr{Void},which::Int,t::Vector{realtype},order::Ptr{Cint},y::N_Vector)
+    ccall((:IDAGetAdjDataPointPolynomial,libsundials_ida),Cint,(Ptr{Void},Cint,Ptr{realtype},Ptr{Cint},N_Vector),ida_mem,which,t,order,y)
+end
+
+function IDAGetAdjCurrentCheckPoint(ida_mem::Ptr{Void},addr::Vector{Ptr{Void}})
+    ccall((:IDAGetAdjCurrentCheckPoint,libsundials_ida),Cint,(Ptr{Void},Ptr{Ptr{Void}}),ida_mem,addr)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/idas/idas_direct.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+
+function IDADlsSetDenseJacFn(ida_mem::Ptr{Void},jac::IDADlsDenseJacFn)
+    ccall((:IDADlsSetDenseJacFn,libsundials_ida),Cint,(Ptr{Void},IDADlsDenseJacFn),ida_mem,jac)
+end
+
+function IDADlsSetBandJacFn(ida_mem::Ptr{Void},jac::IDADlsBandJacFn)
+    ccall((:IDADlsSetBandJacFn,libsundials_ida),Cint,(Ptr{Void},IDADlsBandJacFn),ida_mem,jac)
+end
+
+function IDADlsGetWorkSpace(ida_mem::Ptr{Void},lenrwLS::Ptr{Clong},leniwLS::Ptr{Clong})
+    ccall((:IDADlsGetWorkSpace,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),ida_mem,lenrwLS,leniwLS)
+end
+
+function IDADlsGetNumJacEvals(ida_mem::Ptr{Void},njevals::Ptr{Clong})
+    ccall((:IDADlsGetNumJacEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,njevals)
+end
+
+function IDADlsGetNumResEvals(ida_mem::Ptr{Void},nfevalsLS::Ptr{Clong})
+    ccall((:IDADlsGetNumResEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nfevalsLS)
+end
+
+function IDADlsGetLastFlag(ida_mem::Ptr{Void},flag::Ptr{Clong})
+    ccall((:IDADlsGetLastFlag,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,flag)
+end
+
+function IDADlsGetReturnFlagName(flag::Int)
+    ccall((:IDADlsGetReturnFlagName,libsundials_ida),Ptr{UInt8},(Clong,),flag)
+end
+
+function IDADlsSetDenseJacFnB(ida_mem::Ptr{Void},which::Int,jacB::IDADlsDenseJacFnB)
+    ccall((:IDADlsSetDenseJacFnB,libsundials_ida),Cint,(Ptr{Void},Cint,IDADlsDenseJacFnB),ida_mem,which,jacB)
+end
+
+function IDADlsSetBandJacFnB(idaa_mem::Ptr{Void},which::Int,jacB::IDADlsBandJacFnB)
+    ccall((:IDADlsSetBandJacFnB,libsundials_ida),Cint,(Ptr{Void},Cint,IDADlsBandJacFnB),idaa_mem,which,jacB)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/idas/idas_spils.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function IDASpilsSetPreconditioner(ida_mem::Ptr{Void},pset::IDASpilsPrecSetupFn,psolve::IDASpilsPrecSolveFn)
+    ccall((:IDASpilsSetPreconditioner,libsundials_ida),Cint,(Ptr{Void},IDASpilsPrecSetupFn,IDASpilsPrecSolveFn),ida_mem,pset,psolve)
+end
+
+function IDASpilsSetJacTimesVecFn(ida_mem::Ptr{Void},jtv::IDASpilsJacTimesVecFn)
+    ccall((:IDASpilsSetJacTimesVecFn,libsundials_ida),Cint,(Ptr{Void},IDASpilsJacTimesVecFn),ida_mem,jtv)
+end
+
+function IDASpilsSetGSType(ida_mem::Ptr{Void},gstype::Int)
+    ccall((:IDASpilsSetGSType,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,gstype)
+end
+
+function IDASpilsSetMaxRestarts(ida_mem::Ptr{Void},maxrs::Int)
+    ccall((:IDASpilsSetMaxRestarts,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxrs)
+end
+
+function IDASpilsSetMaxl(ida_mem::Ptr{Void},maxl::Int)
+    ccall((:IDASpilsSetMaxl,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxl)
+end
+
+function IDASpilsSetEpsLin(ida_mem::Ptr{Void},eplifac::realtype)
+    ccall((:IDASpilsSetEpsLin,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,eplifac)
+end
+
+function IDASpilsSetIncrementFactor(ida_mem::Ptr{Void},dqincfac::realtype)
+    ccall((:IDASpilsSetIncrementFactor,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,dqincfac)
+end
+
+function IDASpilsGetWorkSpace(ida_mem::Ptr{Void},lenrwLS::Ptr{Clong},leniwLS::Ptr{Clong})
+    ccall((:IDASpilsGetWorkSpace,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),ida_mem,lenrwLS,leniwLS)
+end
+
+function IDASpilsGetNumPrecEvals(ida_mem::Ptr{Void},npevals::Ptr{Clong})
+    ccall((:IDASpilsGetNumPrecEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,npevals)
+end
+
+function IDASpilsGetNumPrecSolves(ida_mem::Ptr{Void},npsolves::Ptr{Clong})
+    ccall((:IDASpilsGetNumPrecSolves,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,npsolves)
+end
+
+function IDASpilsGetNumLinIters(ida_mem::Ptr{Void},nliters::Ptr{Clong})
+    ccall((:IDASpilsGetNumLinIters,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nliters)
+end
+
+function IDASpilsGetNumConvFails(ida_mem::Ptr{Void},nlcfails::Ptr{Clong})
+    ccall((:IDASpilsGetNumConvFails,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nlcfails)
+end
+
+function IDASpilsGetNumJtimesEvals(ida_mem::Ptr{Void},njvevals::Ptr{Clong})
+    ccall((:IDASpilsGetNumJtimesEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,njvevals)
+end
+
+function IDASpilsGetNumResEvals(ida_mem::Ptr{Void},nrevalsLS::Ptr{Clong})
+    ccall((:IDASpilsGetNumResEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nrevalsLS)
+end
+
+function IDASpilsGetLastFlag(ida_mem::Ptr{Void},flag::Ptr{Clong})
+    ccall((:IDASpilsGetLastFlag,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,flag)
+end
+
+function IDASpilsGetReturnFlagName(flag::Int)
+    ccall((:IDASpilsGetReturnFlagName,libsundials_ida),Ptr{UInt8},(Clong,),flag)
+end
+
+function IDASpilsSetGSTypeB(ida_mem::Ptr{Void},which::Int,gstypeB::Int)
+    ccall((:IDASpilsSetGSTypeB,libsundials_ida),Cint,(Ptr{Void},Cint,Cint),ida_mem,which,gstypeB)
+end
+
+function IDASpilsSetMaxRestartsB(ida_mem::Ptr{Void},which::Int,maxrsB::Int)
+    ccall((:IDASpilsSetMaxRestartsB,libsundials_ida),Cint,(Ptr{Void},Cint,Cint),ida_mem,which,maxrsB)
+end
+
+function IDASpilsSetEpsLinB(ida_mem::Ptr{Void},which::Int,eplifacB::realtype)
+    ccall((:IDASpilsSetEpsLinB,libsundials_ida),Cint,(Ptr{Void},Cint,realtype),ida_mem,which,eplifacB)
+end
+
+function IDASpilsSetMaxlB(ida_mem::Ptr{Void},which::Int,maxlB::Int)
+    ccall((:IDASpilsSetMaxlB,libsundials_ida),Cint,(Ptr{Void},Cint,Cint),ida_mem,which,maxlB)
+end
+
+function IDASpilsSetIncrementFactorB(ida_mem::Ptr{Void},which::Int,dqincfacB::realtype)
+    ccall((:IDASpilsSetIncrementFactorB,libsundials_ida),Cint,(Ptr{Void},Cint,realtype),ida_mem,which,dqincfacB)
+end
+
+function IDASpilsSetPreconditionerB(ida_mem::Ptr{Void},which::Int,psetB::IDASpilsPrecSetupFnB,psolveB::IDASpilsPrecSolveFnB)
+    ccall((:IDASpilsSetPreconditionerB,libsundials_ida),Cint,(Ptr{Void},Cint,IDASpilsPrecSetupFnB,IDASpilsPrecSolveFnB),ida_mem,which,psetB,psolveB)
+end
+
+function IDASpilsSetJacTimesVecFnB(ida_mem::Ptr{Void},which::Int,jtvB::IDASpilsJacTimesVecFnB)
+    ccall((:IDASpilsSetJacTimesVecFnB,libsundials_ida),Cint,(Ptr{Void},Cint,IDASpilsJacTimesVecFnB),ida_mem,which,jtvB)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/idas/idas_band.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function IDABand(ida_mem::Ptr{Void},Neq::Int,mupper::Int,mlower::Int)
+    ccall((:IDABand,libsundials_ida),Cint,(Ptr{Void},Clong,Clong,Clong),ida_mem,Neq,mupper,mlower)
+end
+
+function IDABandB(idaadj_mem::Ptr{Void},which::Int,NeqB::Int,mupperB::Int,mlowerB::Int)
+    ccall((:IDABandB,libsundials_ida),Cint,(Ptr{Void},Cint,Clong,Clong,Clong),idaadj_mem,which,NeqB,mupperB,mlowerB)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/idas/idas_bbdpre.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+
+function IDABBDPrecInit(ida_mem::Ptr{Void},Nlocal::Int,mudq::Int,mldq::Int,mukeep::Int,mlkeep::Int,dq_rel_yy::realtype,Gres::IDABBDLocalFn,Gcomm::IDABBDCommFn)
+    ccall((:IDABBDPrecInit,libsundials_ida),Cint,(Ptr{Void},Clong,Clong,Clong,Clong,Clong,realtype,IDABBDLocalFn,IDABBDCommFn),ida_mem,Nlocal,mudq,mldq,mukeep,mlkeep,dq_rel_yy,Gres,Gcomm)
+end
+
+function IDABBDPrecReInit(ida_mem::Ptr{Void},mudq::Int,mldq::Int,dq_rel_yy::realtype)
+    ccall((:IDABBDPrecReInit,libsundials_ida),Cint,(Ptr{Void},Clong,Clong,realtype),ida_mem,mudq,mldq,dq_rel_yy)
+end
+
+function IDABBDPrecGetWorkSpace(ida_mem::Ptr{Void},lenrwBBDP::Ptr{Clong},leniwBBDP::Ptr{Clong})
+    ccall((:IDABBDPrecGetWorkSpace,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),ida_mem,lenrwBBDP,leniwBBDP)
+end
+
+function IDABBDPrecGetNumGfnEvals(ida_mem::Ptr{Void},ngevalsBBDP::Ptr{Clong})
+    ccall((:IDABBDPrecGetNumGfnEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,ngevalsBBDP)
+end
+
+function IDABBDPrecInitB(ida_mem::Ptr{Void},which::Int,NlocalB::Int,mudqB::Int,mldqB::Int,mukeepB::Int,mlkeepB::Int,dq_rel_yyB::realtype,GresB::IDABBDLocalFnB,GcommB::IDABBDCommFnB)
+    ccall((:IDABBDPrecInitB,libsundials_ida),Cint,(Ptr{Void},Cint,Clong,Clong,Clong,Clong,Clong,realtype,IDABBDLocalFnB,IDABBDCommFnB),ida_mem,which,NlocalB,mudqB,mldqB,mukeepB,mlkeepB,dq_rel_yyB,GresB,GcommB)
+end
+
+function IDABBDPrecReInitB(ida_mem::Ptr{Void},which::Int,mudqB::Int,mldqB::Int,dq_rel_yyB::realtype)
+    ccall((:IDABBDPrecReInitB,libsundials_ida),Cint,(Ptr{Void},Cint,Clong,Clong,realtype),ida_mem,which,mudqB,mldqB,dq_rel_yyB)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/idas/idas_dense.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function IDADense(ida_mem::Ptr{Void},Neq::Int)
+    ccall((:IDADense,libsundials_ida),Cint,(Ptr{Void},Clong),ida_mem,Neq)
+end
+
+function IDADenseB(ida_mem::Ptr{Void},which::Int,NeqB::Int)
+    ccall((:IDADenseB,libsundials_ida),Cint,(Ptr{Void},Cint,Clong),ida_mem,which,NeqB)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/idas/idas_impl.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function IDACreate()
+    ccall((:IDACreate,libsundials_ida),Ptr{Void},())
+end
+
+function IDASetErrHandlerFn(ida_mem::Ptr{Void},ehfun::IDAErrHandlerFn,eh_data::Ptr{Void})
+    ccall((:IDASetErrHandlerFn,libsundials_ida),Cint,(Ptr{Void},IDAErrHandlerFn,Ptr{Void}),ida_mem,ehfun,eh_data)
+end
+
+function IDASetErrFile(ida_mem::Ptr{Void},errfp::Ptr{Void})
+    ccall((:IDASetErrFile,libsundials_ida),Cint,(Ptr{Void},Ptr{Void}),ida_mem,errfp)
+end
+
+function IDASetUserData(ida_mem::Ptr{Void},user_data::Ptr{Void})
+    ccall((:IDASetUserData,libsundials_ida),Cint,(Ptr{Void},Ptr{Void}),ida_mem,user_data)
+end
+
+function IDASetMaxOrd(ida_mem::Ptr{Void},maxord::Int)
+    ccall((:IDASetMaxOrd,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxord)
+end
+
+function IDASetMaxNumSteps(ida_mem::Ptr{Void},mxsteps::Int)
+    ccall((:IDASetMaxNumSteps,libsundials_ida),Cint,(Ptr{Void},Clong),ida_mem,mxsteps)
+end
+
+function IDASetInitStep(ida_mem::Ptr{Void},hin::realtype)
+    ccall((:IDASetInitStep,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,hin)
+end
+
+function IDASetMaxStep(ida_mem::Ptr{Void},hmax::realtype)
+    ccall((:IDASetMaxStep,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,hmax)
+end
+
+function IDASetStopTime(ida_mem::Ptr{Void},tstop::realtype)
+    ccall((:IDASetStopTime,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,tstop)
+end
+
+function IDASetNonlinConvCoef(ida_mem::Ptr{Void},epcon::realtype)
+    ccall((:IDASetNonlinConvCoef,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,epcon)
+end
+
+function IDASetMaxErrTestFails(ida_mem::Ptr{Void},maxnef::Int)
+    ccall((:IDASetMaxErrTestFails,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxnef)
+end
+
+function IDASetMaxNonlinIters(ida_mem::Ptr{Void},maxcor::Int)
+    ccall((:IDASetMaxNonlinIters,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxcor)
+end
+
+function IDASetMaxConvFails(ida_mem::Ptr{Void},maxncf::Int)
+    ccall((:IDASetMaxConvFails,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxncf)
+end
+
+function IDASetSuppressAlg(ida_mem::Ptr{Void},suppressalg::Int)
+    ccall((:IDASetSuppressAlg,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,suppressalg)
+end
+
+function IDASetId(ida_mem::Ptr{Void},id::N_Vector)
+    ccall((:IDASetId,libsundials_ida),Cint,(Ptr{Void},N_Vector),ida_mem,id)
+end
+
+function IDASetConstraints(ida_mem::Ptr{Void},constraints::N_Vector)
+    ccall((:IDASetConstraints,libsundials_ida),Cint,(Ptr{Void},N_Vector),ida_mem,constraints)
+end
+
+function IDASetRootDirection(ida_mem::Ptr{Void},rootdir::Ptr{Cint})
+    ccall((:IDASetRootDirection,libsundials_ida),Cint,(Ptr{Void},Ptr{Cint}),ida_mem,rootdir)
+end
+
+function IDASetNoInactiveRootWarn(ida_mem::Ptr{Void})
+    ccall((:IDASetNoInactiveRootWarn,libsundials_ida),Cint,(Ptr{Void},),ida_mem)
+end
+
+function IDAInit(ida_mem::Ptr{Void},res::IDAResFn,t0::realtype,yy0::N_Vector,yp0::N_Vector)
+    ccall((:IDAInit,libsundials_ida),Cint,(Ptr{Void},IDAResFn,realtype,N_Vector,N_Vector),ida_mem,res,t0,yy0,yp0)
+end
+
+function IDAReInit(ida_mem::Ptr{Void},t0::realtype,yy0::N_Vector,yp0::N_Vector)
+    ccall((:IDAReInit,libsundials_ida),Cint,(Ptr{Void},realtype,N_Vector,N_Vector),ida_mem,t0,yy0,yp0)
+end
+
+function IDASStolerances(ida_mem::Ptr{Void},reltol::realtype,abstol::realtype)
+    ccall((:IDASStolerances,libsundials_ida),Cint,(Ptr{Void},realtype,realtype),ida_mem,reltol,abstol)
+end
+
+function IDASVtolerances(ida_mem::Ptr{Void},reltol::realtype,abstol::N_Vector)
+    ccall((:IDASVtolerances,libsundials_ida),Cint,(Ptr{Void},realtype,N_Vector),ida_mem,reltol,abstol)
+end
+
+function IDAWFtolerances(ida_mem::Ptr{Void},efun::IDAEwtFn)
+    ccall((:IDAWFtolerances,libsundials_ida),Cint,(Ptr{Void},IDAEwtFn),ida_mem,efun)
+end
+
+function IDASetNonlinConvCoefIC(ida_mem::Ptr{Void},epiccon::realtype)
+    ccall((:IDASetNonlinConvCoefIC,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,epiccon)
+end
+
+function IDASetMaxNumStepsIC(ida_mem::Ptr{Void},maxnh::Int)
+    ccall((:IDASetMaxNumStepsIC,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxnh)
+end
+
+function IDASetMaxNumJacsIC(ida_mem::Ptr{Void},maxnj::Int)
+    ccall((:IDASetMaxNumJacsIC,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxnj)
+end
+
+function IDASetMaxNumItersIC(ida_mem::Ptr{Void},maxnit::Int)
+    ccall((:IDASetMaxNumItersIC,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxnit)
+end
+
+function IDASetLineSearchOffIC(ida_mem::Ptr{Void},lsoff::Int)
+    ccall((:IDASetLineSearchOffIC,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,lsoff)
+end
+
+function IDASetStepToleranceIC(ida_mem::Ptr{Void},steptol::realtype)
+    ccall((:IDASetStepToleranceIC,libsundials_ida),Cint,(Ptr{Void},realtype),ida_mem,steptol)
+end
+
+function IDARootInit(ida_mem::Ptr{Void},nrtfn::Int,g::IDARootFn)
+    ccall((:IDARootInit,libsundials_ida),Cint,(Ptr{Void},Cint,IDARootFn),ida_mem,nrtfn,g)
+end
+
+function IDASetQuadErrCon(ida_mem::Ptr{Void},errconQ::Int)
+    ccall((:IDASetQuadErrCon,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,errconQ)
+end
+
+function IDAQuadInit(ida_mem::Ptr{Void},rhsQ::IDAQuadRhsFn,yQ0::N_Vector)
+    ccall((:IDAQuadInit,libsundials_ida),Cint,(Ptr{Void},IDAQuadRhsFn,N_Vector),ida_mem,rhsQ,yQ0)
+end
+
+function IDAQuadReInit(ida_mem::Ptr{Void},yQ0::N_Vector)
+    ccall((:IDAQuadReInit,libsundials_ida),Cint,(Ptr{Void},N_Vector),ida_mem,yQ0)
+end
+
+function IDAQuadSStolerances(ida_mem::Ptr{Void},reltolQ::realtype,abstolQ::realtype)
+    ccall((:IDAQuadSStolerances,libsundials_ida),Cint,(Ptr{Void},realtype,realtype),ida_mem,reltolQ,abstolQ)
+end
+
+function IDAQuadSVtolerances(ida_mem::Ptr{Void},reltolQ::realtype,abstolQ::N_Vector)
+    ccall((:IDAQuadSVtolerances,libsundials_ida),Cint,(Ptr{Void},realtype,N_Vector),ida_mem,reltolQ,abstolQ)
+end
+
+function IDASetSensDQMethod(ida_mem::Ptr{Void},DQtype::Int,DQrhomax::realtype)
+    ccall((:IDASetSensDQMethod,libsundials_ida),Cint,(Ptr{Void},Cint,realtype),ida_mem,DQtype,DQrhomax)
+end
+
+function IDASetSensParams(ida_mem::Ptr{Void},p::Vector{realtype},pbar::Vector{realtype},plist::Ptr{Cint})
+    ccall((:IDASetSensParams,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype},Ptr{realtype},Ptr{Cint}),ida_mem,p,pbar,plist)
+end
+
+function IDASetSensErrCon(ida_mem::Ptr{Void},errconS::Int)
+    ccall((:IDASetSensErrCon,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,errconS)
+end
+
+function IDASetSensMaxNonlinIters(ida_mem::Ptr{Void},maxcorS::Int)
+    ccall((:IDASetSensMaxNonlinIters,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxcorS)
+end
+
+function IDASensInit(ida_mem::Ptr{Void},Ns::Int,ism::Int,resS::IDASensResFn,yS0::Ptr{N_Vector},ypS0::Ptr{N_Vector})
+    ccall((:IDASensInit,libsundials_ida),Cint,(Ptr{Void},Cint,Cint,IDASensResFn,Ptr{N_Vector},Ptr{N_Vector}),ida_mem,Ns,ism,resS,yS0,ypS0)
+end
+
+function IDASensReInit(ida_mem::Ptr{Void},ism::Int,yS0::Ptr{N_Vector},ypS0::Ptr{N_Vector})
+    ccall((:IDASensReInit,libsundials_ida),Cint,(Ptr{Void},Cint,Ptr{N_Vector},Ptr{N_Vector}),ida_mem,ism,yS0,ypS0)
+end
+
+function IDASensToggleOff(ida_mem::Ptr{Void})
+    ccall((:IDASensToggleOff,libsundials_ida),Cint,(Ptr{Void},),ida_mem)
+end
+
+function IDASensSStolerances(ida_mem::Ptr{Void},reltolS::realtype,abstolS::Vector{realtype})
+    ccall((:IDASensSStolerances,libsundials_ida),Cint,(Ptr{Void},realtype,Ptr{realtype}),ida_mem,reltolS,abstolS)
+end
+
+function IDASensSVtolerances(ida_mem::Ptr{Void},reltolS::realtype,abstolS::Ptr{N_Vector})
+    ccall((:IDASensSVtolerances,libsundials_ida),Cint,(Ptr{Void},realtype,Ptr{N_Vector}),ida_mem,reltolS,abstolS)
+end
+
+function IDASensEEtolerances(ida_mem::Ptr{Void})
+    ccall((:IDASensEEtolerances,libsundials_ida),Cint,(Ptr{Void},),ida_mem)
+end
+
+function IDAQuadSensInit(ida_mem::Ptr{Void},resQS::IDAQuadSensRhsFn,yQS0::Ptr{N_Vector})
+    ccall((:IDAQuadSensInit,libsundials_ida),Cint,(Ptr{Void},IDAQuadSensRhsFn,Ptr{N_Vector}),ida_mem,resQS,yQS0)
+end
+
+function IDAQuadSensReInit(ida_mem::Ptr{Void},yQS0::Ptr{N_Vector})
+    ccall((:IDAQuadSensReInit,libsundials_ida),Cint,(Ptr{Void},Ptr{N_Vector}),ida_mem,yQS0)
+end
+
+function IDAQuadSensSStolerances(ida_mem::Ptr{Void},reltolQS::realtype,abstolQS::Vector{realtype})
+    ccall((:IDAQuadSensSStolerances,libsundials_ida),Cint,(Ptr{Void},realtype,Ptr{realtype}),ida_mem,reltolQS,abstolQS)
+end
+
+function IDAQuadSensSVtolerances(ida_mem::Ptr{Void},reltolQS::realtype,abstolQS::Ptr{N_Vector})
+    ccall((:IDAQuadSensSVtolerances,libsundials_ida),Cint,(Ptr{Void},realtype,Ptr{N_Vector}),ida_mem,reltolQS,abstolQS)
+end
+
+function IDAQuadSensEEtolerances(ida_mem::Ptr{Void})
+    ccall((:IDAQuadSensEEtolerances,libsundials_ida),Cint,(Ptr{Void},),ida_mem)
+end
+
+function IDASetQuadSensErrCon(ida_mem::Ptr{Void},errconQS::Int)
+    ccall((:IDASetQuadSensErrCon,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,errconQS)
+end
+
+function IDACalcIC(ida_mem::Ptr{Void},icopt::Int,tout1::realtype)
+    ccall((:IDACalcIC,libsundials_ida),Cint,(Ptr{Void},Cint,realtype),ida_mem,icopt,tout1)
+end
+
+function IDASolve(ida_mem::Ptr{Void},tout::realtype,tret::Vector{realtype},yret::N_Vector,ypret::N_Vector,itask::Int)
+    ccall((:IDASolve,libsundials_ida),Cint,(Ptr{Void},realtype,Ptr{realtype},N_Vector,N_Vector,Cint),ida_mem,tout,tret,yret,ypret,itask)
+end
+
+function IDAGetDky(ida_mem::Ptr{Void},t::realtype,k::Int,dky::N_Vector)
+    ccall((:IDAGetDky,libsundials_ida),Cint,(Ptr{Void},realtype,Cint,N_Vector),ida_mem,t,k,dky)
+end
+
+function IDAGetWorkSpace(ida_mem::Ptr{Void},lenrw::Ptr{Clong},leniw::Ptr{Clong})
+    ccall((:IDAGetWorkSpace,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),ida_mem,lenrw,leniw)
+end
+
+function IDAGetNumSteps(ida_mem::Ptr{Void},nsteps::Ptr{Clong})
+    ccall((:IDAGetNumSteps,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nsteps)
+end
+
+function IDAGetNumResEvals(ida_mem::Ptr{Void},nrevals::Ptr{Clong})
+    ccall((:IDAGetNumResEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nrevals)
+end
+
+function IDAGetNumLinSolvSetups(ida_mem::Ptr{Void},nlinsetups::Ptr{Clong})
+    ccall((:IDAGetNumLinSolvSetups,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nlinsetups)
+end
+
+function IDAGetNumErrTestFails(ida_mem::Ptr{Void},netfails::Ptr{Clong})
+    ccall((:IDAGetNumErrTestFails,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,netfails)
+end
+
+function IDAGetNumBacktrackOps(ida_mem::Ptr{Void},nbacktr::Ptr{Clong})
+    ccall((:IDAGetNumBacktrackOps,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nbacktr)
+end
+
+function IDAGetConsistentIC(ida_mem::Ptr{Void},yy0_mod::N_Vector,yp0_mod::N_Vector)
+    ccall((:IDAGetConsistentIC,libsundials_ida),Cint,(Ptr{Void},N_Vector,N_Vector),ida_mem,yy0_mod,yp0_mod)
+end
+
+function IDAGetLastOrder(ida_mem::Ptr{Void},klast::Ptr{Cint})
+    ccall((:IDAGetLastOrder,libsundials_ida),Cint,(Ptr{Void},Ptr{Cint}),ida_mem,klast)
+end
+
+function IDAGetCurrentOrder(ida_mem::Ptr{Void},kcur::Ptr{Cint})
+    ccall((:IDAGetCurrentOrder,libsundials_ida),Cint,(Ptr{Void},Ptr{Cint}),ida_mem,kcur)
+end
+
+function IDAGetActualInitStep(ida_mem::Ptr{Void},hinused::Vector{realtype})
+    ccall((:IDAGetActualInitStep,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype}),ida_mem,hinused)
+end
+
+function IDAGetLastStep(ida_mem::Ptr{Void},hlast::Vector{realtype})
+    ccall((:IDAGetLastStep,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype}),ida_mem,hlast)
+end
+
+function IDAGetCurrentStep(ida_mem::Ptr{Void},hcur::Vector{realtype})
+    ccall((:IDAGetCurrentStep,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype}),ida_mem,hcur)
+end
+
+function IDAGetCurrentTime(ida_mem::Ptr{Void},tcur::Vector{realtype})
+    ccall((:IDAGetCurrentTime,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype}),ida_mem,tcur)
+end
+
+function IDAGetTolScaleFactor(ida_mem::Ptr{Void},tolsfact::Vector{realtype})
+    ccall((:IDAGetTolScaleFactor,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype}),ida_mem,tolsfact)
+end
+
+function IDAGetErrWeights(ida_mem::Ptr{Void},eweight::N_Vector)
+    ccall((:IDAGetErrWeights,libsundials_ida),Cint,(Ptr{Void},N_Vector),ida_mem,eweight)
+end
+
+function IDAGetEstLocalErrors(ida_mem::Ptr{Void},ele::N_Vector)
+    ccall((:IDAGetEstLocalErrors,libsundials_ida),Cint,(Ptr{Void},N_Vector),ida_mem,ele)
+end
+
+function IDAGetNumGEvals(ida_mem::Ptr{Void},ngevals::Ptr{Clong})
+    ccall((:IDAGetNumGEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,ngevals)
+end
+
+function IDAGetRootInfo(ida_mem::Ptr{Void},rootsfound::Ptr{Cint})
+    ccall((:IDAGetRootInfo,libsundials_ida),Cint,(Ptr{Void},Ptr{Cint}),ida_mem,rootsfound)
+end
+
+function IDAGetIntegratorStats(ida_mem::Ptr{Void},nsteps::Ptr{Clong},nrevals::Ptr{Clong},nlinsetups::Ptr{Clong},netfails::Ptr{Clong},qlast::Ptr{Cint},qcur::Ptr{Cint},hinused::Vector{realtype},hlast::Vector{realtype},hcur::Vector{realtype},tcur::Vector{realtype})
+    ccall((:IDAGetIntegratorStats,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Cint},Ptr{Cint},Ptr{realtype},Ptr{realtype},Ptr{realtype},Ptr{realtype}),ida_mem,nsteps,nrevals,nlinsetups,netfails,qlast,qcur,hinused,hlast,hcur,tcur)
+end
+
+function IDAGetNumNonlinSolvIters(ida_mem::Ptr{Void},nniters::Ptr{Clong})
+    ccall((:IDAGetNumNonlinSolvIters,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nniters)
+end
+
+function IDAGetNumNonlinSolvConvFails(ida_mem::Ptr{Void},nncfails::Ptr{Clong})
+    ccall((:IDAGetNumNonlinSolvConvFails,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nncfails)
+end
+
+function IDAGetNonlinSolvStats(ida_mem::Ptr{Void},nniters::Ptr{Clong},nncfails::Ptr{Clong})
+    ccall((:IDAGetNonlinSolvStats,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),ida_mem,nniters,nncfails)
+end
+
+function IDAGetQuad(ida_mem::Ptr{Void},t::Vector{realtype},yQout::N_Vector)
+    ccall((:IDAGetQuad,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype},N_Vector),ida_mem,t,yQout)
+end
+
+function IDAGetQuadDky(ida_mem::Ptr{Void},t::realtype,k::Int,dky::N_Vector)
+    ccall((:IDAGetQuadDky,libsundials_ida),Cint,(Ptr{Void},realtype,Cint,N_Vector),ida_mem,t,k,dky)
+end
+
+function IDAGetQuadNumRhsEvals(ida_mem::Ptr{Void},nrhsQevals::Ptr{Clong})
+    ccall((:IDAGetQuadNumRhsEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nrhsQevals)
+end
+
+function IDAGetQuadNumErrTestFails(ida_mem::Ptr{Void},nQetfails::Ptr{Clong})
+    ccall((:IDAGetQuadNumErrTestFails,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nQetfails)
+end
+
+function IDAGetQuadErrWeights(ida_mem::Ptr{Void},eQweight::N_Vector)
+    ccall((:IDAGetQuadErrWeights,libsundials_ida),Cint,(Ptr{Void},N_Vector),ida_mem,eQweight)
+end
+
+function IDAGetQuadStats(ida_mem::Ptr{Void},nrhsQevals::Ptr{Clong},nQetfails::Ptr{Clong})
+    ccall((:IDAGetQuadStats,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),ida_mem,nrhsQevals,nQetfails)
+end
+
+function IDAGetSens(ida_mem::Ptr{Void},tret::Vector{realtype},yySout::Ptr{N_Vector})
+    ccall((:IDAGetSens,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype},Ptr{N_Vector}),ida_mem,tret,yySout)
+end
+
+function IDAGetSens1(ida_mem::Ptr{Void},tret::Vector{realtype},is::Int,yySret::N_Vector)
+    ccall((:IDAGetSens1,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype},Cint,N_Vector),ida_mem,tret,is,yySret)
+end
+
+function IDAGetSensDky(ida_mem::Ptr{Void},t::realtype,k::Int,dkyS::Ptr{N_Vector})
+    ccall((:IDAGetSensDky,libsundials_ida),Cint,(Ptr{Void},realtype,Cint,Ptr{N_Vector}),ida_mem,t,k,dkyS)
+end
+
+function IDAGetSensDky1(ida_mem::Ptr{Void},t::realtype,k::Int,is::Int,dkyS::N_Vector)
+    ccall((:IDAGetSensDky1,libsundials_ida),Cint,(Ptr{Void},realtype,Cint,Cint,N_Vector),ida_mem,t,k,is,dkyS)
+end
+
+function IDAGetSensConsistentIC(ida_mem::Ptr{Void},yyS0::Ptr{N_Vector},ypS0::Ptr{N_Vector})
+    ccall((:IDAGetSensConsistentIC,libsundials_ida),Cint,(Ptr{Void},Ptr{N_Vector},Ptr{N_Vector}),ida_mem,yyS0,ypS0)
+end
+
+function IDAGetSensNumResEvals(ida_mem::Ptr{Void},nresSevals::Ptr{Clong})
+    ccall((:IDAGetSensNumResEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nresSevals)
+end
+
+function IDAGetNumResEvalsSens(ida_mem::Ptr{Void},nresevalsS::Ptr{Clong})
+    ccall((:IDAGetNumResEvalsSens,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nresevalsS)
+end
+
+function IDAGetSensNumErrTestFails(ida_mem::Ptr{Void},nSetfails::Ptr{Clong})
+    ccall((:IDAGetSensNumErrTestFails,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nSetfails)
+end
+
+function IDAGetSensNumLinSolvSetups(ida_mem::Ptr{Void},nlinsetupsS::Ptr{Clong})
+    ccall((:IDAGetSensNumLinSolvSetups,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nlinsetupsS)
+end
+
+function IDAGetSensErrWeights(ida_mem::Ptr{Void},eSweight::N_Vector_S)
+    ccall((:IDAGetSensErrWeights,libsundials_ida),Cint,(Ptr{Void},N_Vector_S),ida_mem,eSweight)
+end
+
+function IDAGetSensStats(ida_mem::Ptr{Void},nresSevals::Ptr{Clong},nresevalsS::Ptr{Clong},nSetfails::Ptr{Clong},nlinsetupsS::Ptr{Clong})
+    ccall((:IDAGetSensStats,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Clong}),ida_mem,nresSevals,nresevalsS,nSetfails,nlinsetupsS)
+end
+
+function IDAGetSensNumNonlinSolvIters(ida_mem::Ptr{Void},nSniters::Ptr{Clong})
+    ccall((:IDAGetSensNumNonlinSolvIters,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nSniters)
+end
+
+function IDAGetSensNumNonlinSolvConvFails(ida_mem::Ptr{Void},nSncfails::Ptr{Clong})
+    ccall((:IDAGetSensNumNonlinSolvConvFails,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nSncfails)
+end
+
+function IDAGetSensNonlinSolvStats(ida_mem::Ptr{Void},nSniters::Ptr{Clong},nSncfails::Ptr{Clong})
+    ccall((:IDAGetSensNonlinSolvStats,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),ida_mem,nSniters,nSncfails)
+end
+
+function IDAGetQuadSensNumRhsEvals(ida_mem::Ptr{Void},nrhsQSevals::Ptr{Clong})
+    ccall((:IDAGetQuadSensNumRhsEvals,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nrhsQSevals)
+end
+
+function IDAGetQuadSensNumErrTestFails(ida_mem::Ptr{Void},nQSetfails::Ptr{Clong})
+    ccall((:IDAGetQuadSensNumErrTestFails,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong}),ida_mem,nQSetfails)
+end
+
+function IDAGetQuadSensErrWeights(ida_mem::Ptr{Void},eQSweight::Ptr{N_Vector})
+    ccall((:IDAGetQuadSensErrWeights,libsundials_ida),Cint,(Ptr{Void},Ptr{N_Vector}),ida_mem,eQSweight)
+end
+
+function IDAGetQuadSensStats(ida_mem::Ptr{Void},nrhsQSevals::Ptr{Clong},nQSetfails::Ptr{Clong})
+    ccall((:IDAGetQuadSensStats,libsundials_ida),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),ida_mem,nrhsQSevals,nQSetfails)
+end
+
+function IDAGetQuadSens(ida_mem::Ptr{Void},tret::Vector{realtype},yyQSout::Ptr{N_Vector})
+    ccall((:IDAGetQuadSens,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype},Ptr{N_Vector}),ida_mem,tret,yyQSout)
+end
+
+function IDAGetQuadSens1(ida_mem::Ptr{Void},tret::Vector{realtype},is::Int,yyQSret::N_Vector)
+    ccall((:IDAGetQuadSens1,libsundials_ida),Cint,(Ptr{Void},Ptr{realtype},Cint,N_Vector),ida_mem,tret,is,yyQSret)
+end
+
+function IDAGetQuadSensDky(ida_mem::Ptr{Void},t::realtype,k::Int,dkyQS::Ptr{N_Vector})
+    ccall((:IDAGetQuadSensDky,libsundials_ida),Cint,(Ptr{Void},realtype,Cint,Ptr{N_Vector}),ida_mem,t,k,dkyQS)
+end
+
+function IDAGetQuadSensDky1(ida_mem::Ptr{Void},t::realtype,k::Int,is::Int,dkyQS::N_Vector)
+    ccall((:IDAGetQuadSensDky1,libsundials_ida),Cint,(Ptr{Void},realtype,Cint,Cint,N_Vector),ida_mem,t,k,is,dkyQS)
+end
+
+function IDAGetReturnFlagName(flag::Int)
+    ccall((:IDAGetReturnFlagName,libsundials_ida),Ptr{UInt8},(Clong,),flag)
+end
+
+function IDAFree(ida_mem::Vector{Ptr{Void}})
+    ccall((:IDAFree,libsundials_ida),Void,(Ptr{Ptr{Void}},),ida_mem)
+end
+
+function IDAQuadFree(ida_mem::Ptr{Void})
+    ccall((:IDAQuadFree,libsundials_ida),Void,(Ptr{Void},),ida_mem)
+end
+
+function IDASensFree(ida_mem::Ptr{Void})
+    ccall((:IDASensFree,libsundials_ida),Void,(Ptr{Void},),ida_mem)
+end
+
+function IDAQuadSensFree(ida_mem::Ptr{Void})
+    ccall((:IDAQuadSensFree,libsundials_ida),Void,(Ptr{Void},),ida_mem)
+end
+
+function IDAAdjInit(ida_mem::Ptr{Void},steps::Int,interp::Int)
+    ccall((:IDAAdjInit,libsundials_ida),Cint,(Ptr{Void},Clong,Cint),ida_mem,steps,interp)
+end
+
+function IDAAdjReInit(ida_mem::Ptr{Void})
+    ccall((:IDAAdjReInit,libsundials_ida),Cint,(Ptr{Void},),ida_mem)
+end
+
+function IDAAdjFree(ida_mem::Ptr{Void})
+    ccall((:IDAAdjFree,libsundials_ida),Void,(Ptr{Void},),ida_mem)
+end
+
+function IDACreateB(ida_mem::Ptr{Void},which::Ptr{Cint})
+    ccall((:IDACreateB,libsundials_ida),Cint,(Ptr{Void},Ptr{Cint}),ida_mem,which)
+end
+
+function IDAInitB(ida_mem::Ptr{Void},which::Int,resB::IDAResFnB,tB0::realtype,yyB0::N_Vector,ypB0::N_Vector)
+    ccall((:IDAInitB,libsundials_ida),Cint,(Ptr{Void},Cint,IDAResFnB,realtype,N_Vector,N_Vector),ida_mem,which,resB,tB0,yyB0,ypB0)
+end
+
+function IDAInitBS(ida_mem::Ptr{Void},which::Int,resS::IDAResFnBS,tB0::realtype,yyB0::N_Vector,ypB0::N_Vector)
+    ccall((:IDAInitBS,libsundials_ida),Cint,(Ptr{Void},Cint,IDAResFnBS,realtype,N_Vector,N_Vector),ida_mem,which,resS,tB0,yyB0,ypB0)
+end
+
+function IDAReInitB(ida_mem::Ptr{Void},which::Int,tB0::realtype,yyB0::N_Vector,ypB0::N_Vector)
+    ccall((:IDAReInitB,libsundials_ida),Cint,(Ptr{Void},Cint,realtype,N_Vector,N_Vector),ida_mem,which,tB0,yyB0,ypB0)
+end
+
+function IDASStolerancesB(ida_mem::Ptr{Void},which::Int,relTolB::realtype,absTolB::realtype)
+    ccall((:IDASStolerancesB,libsundials_ida),Cint,(Ptr{Void},Cint,realtype,realtype),ida_mem,which,relTolB,absTolB)
+end
+
+function IDASVtolerancesB(ida_mem::Ptr{Void},which::Int,relTolB::realtype,absTolB::N_Vector)
+    ccall((:IDASVtolerancesB,libsundials_ida),Cint,(Ptr{Void},Cint,realtype,N_Vector),ida_mem,which,relTolB,absTolB)
+end
+
+function IDAQuadInitB(ida_mem::Ptr{Void},which::Int,rhsQB::IDAQuadRhsFnB,yQB0::N_Vector)
+    ccall((:IDAQuadInitB,libsundials_ida),Cint,(Ptr{Void},Cint,IDAQuadRhsFnB,N_Vector),ida_mem,which,rhsQB,yQB0)
+end
+
+function IDAQuadInitBS(ida_mem::Ptr{Void},which::Int,rhsQS::IDAQuadRhsFnBS,yQB0::N_Vector)
+    ccall((:IDAQuadInitBS,libsundials_ida),Cint,(Ptr{Void},Cint,IDAQuadRhsFnBS,N_Vector),ida_mem,which,rhsQS,yQB0)
+end
+
+function IDAQuadReInitB(ida_mem::Ptr{Void},which::Int,yQB0::N_Vector)
+    ccall((:IDAQuadReInitB,libsundials_ida),Cint,(Ptr{Void},Cint,N_Vector),ida_mem,which,yQB0)
+end
+
+function IDAQuadSStolerancesB(ida_mem::Ptr{Void},which::Int,reltolQB::realtype,abstolQB::realtype)
+    ccall((:IDAQuadSStolerancesB,libsundials_ida),Cint,(Ptr{Void},Cint,realtype,realtype),ida_mem,which,reltolQB,abstolQB)
+end
+
+function IDAQuadSVtolerancesB(ida_mem::Ptr{Void},which::Int,reltolQB::realtype,abstolQB::N_Vector)
+    ccall((:IDAQuadSVtolerancesB,libsundials_ida),Cint,(Ptr{Void},Cint,realtype,N_Vector),ida_mem,which,reltolQB,abstolQB)
+end
+
+function IDACalcICB(ida_mem::Ptr{Void},which::Int,tout1::realtype,yy0::N_Vector,yp0::N_Vector)
+    ccall((:IDACalcICB,libsundials_ida),Cint,(Ptr{Void},Cint,realtype,N_Vector,N_Vector),ida_mem,which,tout1,yy0,yp0)
+end
+
+function IDACalcICBS(ida_mem::Ptr{Void},which::Int,tout1::realtype,yy0::N_Vector,yp0::N_Vector,yyS0::Ptr{N_Vector},ypS0::Ptr{N_Vector})
+    ccall((:IDACalcICBS,libsundials_ida),Cint,(Ptr{Void},Cint,realtype,N_Vector,N_Vector,Ptr{N_Vector},Ptr{N_Vector}),ida_mem,which,tout1,yy0,yp0,yyS0,ypS0)
+end
+
+function IDASolveF(ida_mem::Ptr{Void},tout::realtype,tret::Vector{realtype},yret::N_Vector,ypret::N_Vector,itask::Int,ncheckPtr::Ptr{Cint})
+    ccall((:IDASolveF,libsundials_ida),Cint,(Ptr{Void},realtype,Ptr{realtype},N_Vector,N_Vector,Cint,Ptr{Cint}),ida_mem,tout,tret,yret,ypret,itask,ncheckPtr)
+end
+
+function IDASolveB(ida_mem::Ptr{Void},tBout::realtype,itaskB::Int)
+    ccall((:IDASolveB,libsundials_ida),Cint,(Ptr{Void},realtype,Cint),ida_mem,tBout,itaskB)
+end
+
+function IDASetAdjNoSensi(ida_mem::Ptr{Void})
+    ccall((:IDASetAdjNoSensi,libsundials_ida),Cint,(Ptr{Void},),ida_mem)
+end
+
+function IDASetUserDataB(ida_mem::Ptr{Void},which::Int,user_dataB::Ptr{Void})
+    ccall((:IDASetUserDataB,libsundials_ida),Cint,(Ptr{Void},Cint,Ptr{Void}),ida_mem,which,user_dataB)
+end
+
+function IDASetMaxOrdB(ida_mem::Ptr{Void},which::Int,maxordB::Int)
+    ccall((:IDASetMaxOrdB,libsundials_ida),Cint,(Ptr{Void},Cint,Cint),ida_mem,which,maxordB)
+end
+
+function IDASetMaxNumStepsB(ida_mem::Ptr{Void},which::Int,mxstepsB::Int)
+    ccall((:IDASetMaxNumStepsB,libsundials_ida),Cint,(Ptr{Void},Cint,Clong),ida_mem,which,mxstepsB)
+end
+
+function IDASetInitStepB(ida_mem::Ptr{Void},which::Int,hinB::realtype)
+    ccall((:IDASetInitStepB,libsundials_ida),Cint,(Ptr{Void},Cint,realtype),ida_mem,which,hinB)
+end
+
+function IDASetMaxStepB(ida_mem::Ptr{Void},which::Int,hmaxB::realtype)
+    ccall((:IDASetMaxStepB,libsundials_ida),Cint,(Ptr{Void},Cint,realtype),ida_mem,which,hmaxB)
+end
+
+function IDASetSuppressAlgB(ida_mem::Ptr{Void},which::Int,suppressalgB::Int)
+    ccall((:IDASetSuppressAlgB,libsundials_ida),Cint,(Ptr{Void},Cint,Cint),ida_mem,which,suppressalgB)
+end
+
+function IDASetIdB(ida_mem::Ptr{Void},which::Int,idB::N_Vector)
+    ccall((:IDASetIdB,libsundials_ida),Cint,(Ptr{Void},Cint,N_Vector),ida_mem,which,idB)
+end
+
+function IDASetConstraintsB(ida_mem::Ptr{Void},which::Int,constraintsB::N_Vector)
+    ccall((:IDASetConstraintsB,libsundials_ida),Cint,(Ptr{Void},Cint,N_Vector),ida_mem,which,constraintsB)
+end
+
+function IDASetQuadErrConB(ida_mem::Ptr{Void},which::Int,errconQB::Int)
+    ccall((:IDASetQuadErrConB,libsundials_ida),Cint,(Ptr{Void},Cint,Cint),ida_mem,which,errconQB)
+end
+
+function IDAGetB(ida_mem::Ptr{Void},which::Int,tret::Vector{realtype},yy::N_Vector,yp::N_Vector)
+    ccall((:IDAGetB,libsundials_ida),Cint,(Ptr{Void},Cint,Ptr{realtype},N_Vector,N_Vector),ida_mem,which,tret,yy,yp)
+end
+
+function IDAGetQuadB(ida_mem::Ptr{Void},which::Int,tret::Vector{realtype},qB::N_Vector)
+    ccall((:IDAGetQuadB,libsundials_ida),Cint,(Ptr{Void},Cint,Ptr{realtype},N_Vector),ida_mem,which,tret,qB)
+end
+
+function IDAGetAdjIDABmem(ida_mem::Ptr{Void},which::Int)
+    ccall((:IDAGetAdjIDABmem,libsundials_ida),Ptr{Void},(Ptr{Void},Cint),ida_mem,which)
+end
+
+function IDAGetConsistentICB(ida_mem::Ptr{Void},which::Int,yyB0::N_Vector,ypB0::N_Vector)
+    ccall((:IDAGetConsistentICB,libsundials_ida),Cint,(Ptr{Void},Cint,N_Vector,N_Vector),ida_mem,which,yyB0,ypB0)
+end
+
+function IDAGetAdjY(ida_mem::Ptr{Void},t::realtype,yy::N_Vector,yp::N_Vector)
+    ccall((:IDAGetAdjY,libsundials_ida),Cint,(Ptr{Void},realtype,N_Vector,N_Vector),ida_mem,t,yy,yp)
+end
+
+function IDAGetAdjCheckPointsInfo(ida_mem::Ptr{Void},ckpnt::Ptr{IDAadjCheckPointRec})
+    ccall((:IDAGetAdjCheckPointsInfo,libsundials_ida),Cint,(Ptr{Void},Ptr{IDAadjCheckPointRec}),ida_mem,ckpnt)
+end
+
+function IDAGetAdjDataPointHermite(ida_mem::Ptr{Void},which::Int,t::Vector{realtype},yy::N_Vector,yd::N_Vector)
+    ccall((:IDAGetAdjDataPointHermite,libsundials_ida),Cint,(Ptr{Void},Cint,Ptr{realtype},N_Vector,N_Vector),ida_mem,which,t,yy,yd)
+end
+
+function IDAGetAdjDataPointPolynomial(ida_mem::Ptr{Void},which::Int,t::Vector{realtype},order::Ptr{Cint},y::N_Vector)
+    ccall((:IDAGetAdjDataPointPolynomial,libsundials_ida),Cint,(Ptr{Void},Cint,Ptr{realtype},Ptr{Cint},N_Vector),ida_mem,which,t,order,y)
+end
+
+function IDAGetAdjCurrentCheckPoint(ida_mem::Ptr{Void},addr::Vector{Ptr{Void}})
+    ccall((:IDAGetAdjCurrentCheckPoint,libsundials_ida),Cint,(Ptr{Void},Ptr{Ptr{Void}}),ida_mem,addr)
+end
+
+function IDAEwtSet(ycur::N_Vector,weight::N_Vector,data::Ptr{Void})
+    ccall((:IDAEwtSet,libsundials_ida),Cint,(N_Vector,N_Vector,Ptr{Void}),ycur,weight,data)
+end
+
+function IDAErrHandler(error_code::Int,_module::Ptr{UInt8},_function::Ptr{UInt8},msg::Ptr{UInt8},data::Ptr{Void})
+    ccall((:IDAErrHandler,libsundials_ida),Void,(Cint,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},Ptr{Void}),error_code,_module,_function,msg,data)
+end
+
+function IDASensResDQ(Ns::Int,t::realtype,yy::N_Vector,yp::N_Vector,resval::N_Vector,yyS::Ptr{N_Vector},ypS::Ptr{N_Vector},resvalS::Ptr{N_Vector},user_dataS::Ptr{Void},ytemp::N_Vector,yptemp::N_Vector,restemp::N_Vector)
+    ccall((:IDASensResDQ,libsundials_ida),Cint,(Cint,realtype,N_Vector,N_Vector,N_Vector,Ptr{N_Vector},Ptr{N_Vector},Ptr{N_Vector},Ptr{Void},N_Vector,N_Vector,N_Vector),Ns,t,yy,yp,resval,yyS,ypS,resvalS,user_dataS,ytemp,yptemp,restemp)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/idas/idas_spbcgs.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function SpbcgMalloc(l_max::Int,vec_tmpl::N_Vector)
+    ccall((:SpbcgMalloc,libsundials_ida),SpbcgMem,(Cint,N_Vector),l_max,vec_tmpl)
+end
+
+function SpbcgSolve(mem::SpbcgMem,A_data::Ptr{Void},x::N_Vector,b::N_Vector,pretype::Int,delta::realtype,P_data::Ptr{Void},sx::N_Vector,sb::N_Vector,atimes::ATimesFn,psolve::PSolveFn,res_norm::Vector{realtype},nli::Ptr{Cint},nps::Ptr{Cint})
+    ccall((:SpbcgSolve,libsundials_ida),Cint,(SpbcgMem,Ptr{Void},N_Vector,N_Vector,Cint,realtype,Ptr{Void},N_Vector,N_Vector,ATimesFn,PSolveFn,Ptr{realtype},Ptr{Cint},Ptr{Cint}),mem,A_data,x,b,pretype,delta,P_data,sx,sb,atimes,psolve,res_norm,nli,nps)
+end
+
+function SpbcgFree(mem::SpbcgMem)
+    ccall((:SpbcgFree,libsundials_ida),Void,(SpbcgMem,),mem)
+end
+
+function IDASpbcg(ida_mem::Ptr{Void},maxl::Int)
+    ccall((:IDASpbcg,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxl)
+end
+
+function IDASpbcgB(ida_mem::Ptr{Void},which::Int,maxlB::Int)
+    ccall((:IDASpbcgB,libsundials_ida),Cint,(Ptr{Void},Cint,Cint),ida_mem,which,maxlB)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/idas/idas_spgmr.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function IDASpgmr(ida_mem::Ptr{Void},maxl::Int)
+    ccall((:IDASpgmr,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxl)
+end
+
+function IDASpgmrB(ida_mem::Ptr{Void},which::Int,maxlB::Int)
+    ccall((:IDASpgmrB,libsundials_ida),Cint,(Ptr{Void},Cint,Cint),ida_mem,which,maxlB)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/idas/idas_sptfqmr.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function SptfqmrMalloc(l_max::Int,vec_tmpl::N_Vector)
+    ccall((:SptfqmrMalloc,libsundials_ida),SptfqmrMem,(Cint,N_Vector),l_max,vec_tmpl)
+end
+
+function SptfqmrSolve(mem::SptfqmrMem,A_data::Ptr{Void},x::N_Vector,b::N_Vector,pretype::Int,delta::realtype,P_data::Ptr{Void},sx::N_Vector,sb::N_Vector,atimes::ATimesFn,psolve::PSolveFn,res_norm::Vector{realtype},nli::Ptr{Cint},nps::Ptr{Cint})
+    ccall((:SptfqmrSolve,libsundials_ida),Cint,(SptfqmrMem,Ptr{Void},N_Vector,N_Vector,Cint,realtype,Ptr{Void},N_Vector,N_Vector,ATimesFn,PSolveFn,Ptr{realtype},Ptr{Cint},Ptr{Cint}),mem,A_data,x,b,pretype,delta,P_data,sx,sb,atimes,psolve,res_norm,nli,nps)
+end
+
+function SptfqmrFree(mem::SptfqmrMem)
+    ccall((:SptfqmrFree,libsundials_ida),Void,(SptfqmrMem,),mem)
+end
+
+function IDASptfqmr(ida_mem::Ptr{Void},maxl::Int)
+    ccall((:IDASptfqmr,libsundials_ida),Cint,(Ptr{Void},Cint),ida_mem,maxl)
+end
+
+function IDASptfqmrB(ida_mem::Ptr{Void},which::Int,maxlB::Int)
+    ccall((:IDASptfqmrB,libsundials_ida),Cint,(Ptr{Void},Cint,Cint),ida_mem,which,maxlB)
+end

--- a/src/kinsol.jl
+++ b/src/kinsol.jl
@@ -1,118 +1,424 @@
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/kinsol/kinsol.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
 
-recurs_sym_type(ex::Any) = 
-  (ex==None || typeof(ex)==Symbol || length(ex.args)==1) ? eval(ex) : Expr(ex.head, ex.args[1], recurs_sym_type(ex.args[2]))
-macro c(ret_type, func, arg_types, lib)
-  local _arg_types = Expr(:tuple, [recurs_sym_type(a) for a in arg_types.args]...)
-  local _ret_type = recurs_sym_type(ret_type)
-  local _args_in = Any[ symbol(string('a',x)) for x in 1:length(_arg_types.args) ]
-  local _lib = eval(lib)
-  quote
-    $(esc(func))($(_args_in...)) = ccall( ($(string(func)), $(Expr(:quote, _lib)) ), $_ret_type, $_arg_types, $(_args_in...) )
-  end
+function KINCreate()
+    ccall((:KINCreate,libsundials_kinsol),Ptr{Void},())
 end
 
-macro ctypedef(fake_t,real_t)
-  real_t = recurs_sym_type(real_t)
-  quote
-    typealias $fake_t $real_t
-  end
+function KINSetErrHandlerFn(kinmem::Ptr{Void},ehfun::KINErrHandlerFn,eh_data::Ptr{Void})
+    ccall((:KINSetErrHandlerFn,libsundials_kinsol),Cint,(Ptr{Void},KINErrHandlerFn,Ptr{Void}),kinmem,ehfun,eh_data)
 end
 
-# header: /usr/local/include/kinsol/kinsol_band.h
-@ctypedef KINDlsDenseJacFn Ptr{:Void}
-@ctypedef KINDlsBandJacFn Ptr{:Void}
-@c Int32 KINDlsSetDenseJacFn (Ptr{:None},:KINDlsDenseJacFn) shlib
-@c Int32 KINDlsSetBandJacFn (Ptr{:None},:KINDlsBandJacFn) shlib
-@c Int32 KINDlsGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 KINDlsGetNumJacEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINDlsGetNumFuncEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINDlsGetLastFlag (Ptr{:None},Ptr{:Clong}) shlib
-@c Ptr{:Uint8} KINDlsGetReturnFlagName (:Clong,) shlib
-@c Int32 KINBand (Ptr{:None},:Clong,:Clong,:Clong) shlib
+function KINSetErrFile(kinmem::Ptr{Void},errfp::Ptr{Void})
+    ccall((:KINSetErrFile,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Void}),kinmem,errfp)
+end
 
-# header: /usr/local/include/kinsol/kinsol_bbdpre.h
-@ctypedef KINCommFn Ptr{:Void}
-@ctypedef KINLocalFn Ptr{:Void}
-@c Int32 KINBBDPrecInit (Ptr{:None},:Clong,:Clong,:Clong,:Clong,:Clong,:realtype,:KINLocalFn,:KINCommFn) shlib
-@c Int32 KINBBDPrecGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 KINBBDPrecGetNumGfnEvals (Ptr{:None},Ptr{:Clong}) shlib
+function KINSetInfoHandlerFn(kinmem::Ptr{Void},ihfun::KINInfoHandlerFn,ih_data::Ptr{Void})
+    ccall((:KINSetInfoHandlerFn,libsundials_kinsol),Cint,(Ptr{Void},KINInfoHandlerFn,Ptr{Void}),kinmem,ihfun,ih_data)
+end
 
-# header: /usr/local/include/kinsol/kinsol_dense.h
-@c Int32 KINDense (Ptr{:None},:Clong) shlib
+function KINSetInfoFile(kinmem::Ptr{Void},infofp::Ptr{Void})
+    ccall((:KINSetInfoFile,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Void}),kinmem,infofp)
+end
 
-# header: /usr/local/include/kinsol/kinsol_direct.h
+function KINSetUserData(kinmem::Ptr{Void},user_data::Ptr{Void})
+    ccall((:KINSetUserData,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Void}),kinmem,user_data)
+end
 
-# header: /usr/local/include/kinsol/kinsol.h
-@ctypedef KINSysFn Ptr{:Void}
-@ctypedef KINErrHandlerFn Ptr{:Void}
-@ctypedef KINInfoHandlerFn Ptr{:Void}
-@c Ptr{:None} KINCreate () shlib
-@c Int32 KINSetErrHandlerFn (Ptr{:None},:KINErrHandlerFn,Ptr{:None}) shlib
-@c Int32 KINSetErrFile (Ptr{:None},Ptr{:FILE}) shlib
-@c Int32 KINSetInfoHandlerFn (Ptr{:None},:KINInfoHandlerFn,Ptr{:None}) shlib
-@c Int32 KINSetInfoFile (Ptr{:None},Ptr{:FILE}) shlib
-@c Int32 KINSetUserData (Ptr{:None},Ptr{:None}) shlib
-@c Int32 KINSetPrintLevel (Ptr{:None},:Int32) shlib
-@c Int32 KINSetNumMaxIters (Ptr{:None},:Clong) shlib
-@c Int32 KINSetNoInitSetup (Ptr{:None},:Int32) shlib
-@c Int32 KINSetNoResMon (Ptr{:None},:Int32) shlib
-@c Int32 KINSetMaxSetupCalls (Ptr{:None},:Clong) shlib
-@c Int32 KINSetMaxSubSetupCalls (Ptr{:None},:Clong) shlib
-@c Int32 KINSetEtaForm (Ptr{:None},:Int32) shlib
-@c Int32 KINSetEtaConstValue (Ptr{:None},:realtype) shlib
-@c Int32 KINSetEtaParams (Ptr{:None},:realtype,:realtype) shlib
-@c Int32 KINSetResMonParams (Ptr{:None},:realtype,:realtype) shlib
-@c Int32 KINSetResMonConstValue (Ptr{:None},:realtype) shlib
-@c Int32 KINSetNoMinEps (Ptr{:None},:Int32) shlib
-@c Int32 KINSetMaxNewtonStep (Ptr{:None},:realtype) shlib
-@c Int32 KINSetMaxBetaFails (Ptr{:None},:Clong) shlib
-@c Int32 KINSetRelErrFunc (Ptr{:None},:realtype) shlib
-@c Int32 KINSetFuncNormTol (Ptr{:None},:realtype) shlib
-@c Int32 KINSetScaledStepTol (Ptr{:None},:realtype) shlib
-@c Int32 KINSetConstraints (Ptr{:None},:N_Vector) shlib
-@c Int32 KINSetSysFunc (Ptr{:None},:KINSysFn) shlib
-@c Int32 KINInit (Ptr{:None},:KINSysFn,:N_Vector) shlib
-@c Int32 KINSol (Ptr{:None},:N_Vector,:Int32,:N_Vector,:N_Vector) shlib
-@c Int32 KINGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 KINGetNumNonlinSolvIters (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINGetNumFuncEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINGetNumBetaCondFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINGetNumBacktrackOps (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINGetFuncNorm (Ptr{:None},Ptr{:realtype}) shlib
-@c Int32 KINGetStepLength (Ptr{:None},Ptr{:realtype}) shlib
-@c Ptr{:Uint8} KINGetReturnFlagName (:Clong,) shlib
-@c None KINFree (Ptr{Ptr{:None}},) shlib
+function KINSetPrintLevel(kinmemm::Ptr{Void},printfl::Int)
+    ccall((:KINSetPrintLevel,libsundials_kinsol),Cint,(Ptr{Void},Cint),kinmemm,printfl)
+end
 
-# header: /usr/local/include/kinsol/kinsol_impl.h
-@ctypedef KINMem Ptr{:Void}
-@c None KINProcessError (:KINMem,:Int32,Ptr{:Uint8},Ptr{:Uint8},Ptr{:Uint8}) shlib
-@c None KINErrHandler (:Int32,Ptr{:Uint8},Ptr{:Uint8},Ptr{:Uint8},Ptr{:None}) shlib
-@c None KINPrintInfo (:KINMem,:Int32,Ptr{:Uint8},Ptr{:Uint8},Ptr{:Uint8}) shlib
-@c None KINInfoHandler (Ptr{:Uint8},Ptr{:Uint8},Ptr{:Uint8},Ptr{:None}) shlib
+function KINSetNumMaxIters(kinmem::Ptr{Void},mxiter::Int)
+    ccall((:KINSetNumMaxIters,libsundials_kinsol),Cint,(Ptr{Void},Clong),kinmem,mxiter)
+end
 
-# header: /usr/local/include/kinsol/kinsol_spbcgs.h
-@ctypedef KINSpilsPrecSetupFn Ptr{:Void}
-@ctypedef KINSpilsPrecSolveFn Ptr{:Void}
-@ctypedef KINSpilsJacTimesVecFn Ptr{:Void}
-@c Int32 KINSpilsSetMaxRestarts (Ptr{:None},:Int32) shlib
-@c Int32 KINSpilsSetPreconditioner (Ptr{:None},:KINSpilsPrecSetupFn,:KINSpilsPrecSolveFn) shlib
-@c Int32 KINSpilsSetJacTimesVecFn (Ptr{:None},:KINSpilsJacTimesVecFn) shlib
-@c Int32 KINSpilsGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 KINSpilsGetNumPrecEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINSpilsGetNumPrecSolves (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINSpilsGetNumLinIters (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINSpilsGetNumConvFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINSpilsGetNumJtimesEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINSpilsGetNumFuncEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINSpilsGetLastFlag (Ptr{:None},Ptr{:Clong}) shlib
-@c Ptr{:Uint8} KINSpilsGetReturnFlagName (:Clong,) shlib
-@c Int32 KINSpbcg (Ptr{:None},:Int32) shlib
+function KINSetNoInitSetup(kinmem::Ptr{Void},noInitSetup::Int)
+    ccall((:KINSetNoInitSetup,libsundials_kinsol),Cint,(Ptr{Void},Cint),kinmem,noInitSetup)
+end
 
-# header: /usr/local/include/kinsol/kinsol_spgmr.h
-@c Int32 KINSpgmr (Ptr{:None},:Int32) shlib
+function KINSetNoResMon(kinmem::Ptr{Void},noNNIResMon::Int)
+    ccall((:KINSetNoResMon,libsundials_kinsol),Cint,(Ptr{Void},Cint),kinmem,noNNIResMon)
+end
 
-# header: /usr/local/include/kinsol/kinsol_spils.h
+function KINSetMaxSetupCalls(kinmem::Ptr{Void},msbset::Int)
+    ccall((:KINSetMaxSetupCalls,libsundials_kinsol),Cint,(Ptr{Void},Clong),kinmem,msbset)
+end
 
-# header: /usr/local/include/kinsol/kinsol_sptfqmr.h
-@c Int32 KINSptfqmr (Ptr{:None},:Int32) shlib
+function KINSetMaxSubSetupCalls(kinmem::Ptr{Void},msbsetsub::Int)
+    ccall((:KINSetMaxSubSetupCalls,libsundials_kinsol),Cint,(Ptr{Void},Clong),kinmem,msbsetsub)
+end
 
+function KINSetEtaForm(kinmem::Ptr{Void},etachoice::Int)
+    ccall((:KINSetEtaForm,libsundials_kinsol),Cint,(Ptr{Void},Cint),kinmem,etachoice)
+end
+
+function KINSetEtaConstValue(kinmem::Ptr{Void},eta::realtype)
+    ccall((:KINSetEtaConstValue,libsundials_kinsol),Cint,(Ptr{Void},realtype),kinmem,eta)
+end
+
+function KINSetEtaParams(kinmem::Ptr{Void},egamma::realtype,ealpha::realtype)
+    ccall((:KINSetEtaParams,libsundials_kinsol),Cint,(Ptr{Void},realtype,realtype),kinmem,egamma,ealpha)
+end
+
+function KINSetResMonParams(kinmem::Ptr{Void},omegamin::realtype,omegamax::realtype)
+    ccall((:KINSetResMonParams,libsundials_kinsol),Cint,(Ptr{Void},realtype,realtype),kinmem,omegamin,omegamax)
+end
+
+function KINSetResMonConstValue(kinmem::Ptr{Void},omegaconst::realtype)
+    ccall((:KINSetResMonConstValue,libsundials_kinsol),Cint,(Ptr{Void},realtype),kinmem,omegaconst)
+end
+
+function KINSetNoMinEps(kinmem::Ptr{Void},noMinEps::Int)
+    ccall((:KINSetNoMinEps,libsundials_kinsol),Cint,(Ptr{Void},Cint),kinmem,noMinEps)
+end
+
+function KINSetMaxNewtonStep(kinmem::Ptr{Void},mxnewtstep::realtype)
+    ccall((:KINSetMaxNewtonStep,libsundials_kinsol),Cint,(Ptr{Void},realtype),kinmem,mxnewtstep)
+end
+
+function KINSetMaxBetaFails(kinmem::Ptr{Void},mxnbcf::Int)
+    ccall((:KINSetMaxBetaFails,libsundials_kinsol),Cint,(Ptr{Void},Clong),kinmem,mxnbcf)
+end
+
+function KINSetRelErrFunc(kinmem::Ptr{Void},relfunc::realtype)
+    ccall((:KINSetRelErrFunc,libsundials_kinsol),Cint,(Ptr{Void},realtype),kinmem,relfunc)
+end
+
+function KINSetFuncNormTol(kinmem::Ptr{Void},fnormtol::realtype)
+    ccall((:KINSetFuncNormTol,libsundials_kinsol),Cint,(Ptr{Void},realtype),kinmem,fnormtol)
+end
+
+function KINSetScaledStepTol(kinmem::Ptr{Void},scsteptol::realtype)
+    ccall((:KINSetScaledStepTol,libsundials_kinsol),Cint,(Ptr{Void},realtype),kinmem,scsteptol)
+end
+
+function KINSetConstraints(kinmem::Ptr{Void},constraints::N_Vector)
+    ccall((:KINSetConstraints,libsundials_kinsol),Cint,(Ptr{Void},N_Vector),kinmem,constraints)
+end
+
+function KINSetSysFunc(kinmem::Ptr{Void},func::KINSysFn)
+    ccall((:KINSetSysFunc,libsundials_kinsol),Cint,(Ptr{Void},KINSysFn),kinmem,func)
+end
+
+function KINInit(kinmem::Ptr{Void},func::KINSysFn,tmpl::N_Vector)
+    ccall((:KINInit,libsundials_kinsol),Cint,(Ptr{Void},KINSysFn,N_Vector),kinmem,func,tmpl)
+end
+
+function KINSol(kinmem::Ptr{Void},uu::N_Vector,strategy::Int,u_scale::N_Vector,f_scale::N_Vector)
+    ccall((:KINSol,libsundials_kinsol),Cint,(Ptr{Void},N_Vector,Cint,N_Vector,N_Vector),kinmem,uu,strategy,u_scale,f_scale)
+end
+
+function KINGetWorkSpace(kinmem::Ptr{Void},lenrw::Ptr{Clong},leniw::Ptr{Clong})
+    ccall((:KINGetWorkSpace,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),kinmem,lenrw,leniw)
+end
+
+function KINGetNumNonlinSolvIters(kinmem::Ptr{Void},nniters::Ptr{Clong})
+    ccall((:KINGetNumNonlinSolvIters,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong}),kinmem,nniters)
+end
+
+function KINGetNumFuncEvals(kinmem::Ptr{Void},nfevals::Ptr{Clong})
+    ccall((:KINGetNumFuncEvals,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong}),kinmem,nfevals)
+end
+
+function KINGetNumBetaCondFails(kinmem::Ptr{Void},nbcfails::Ptr{Clong})
+    ccall((:KINGetNumBetaCondFails,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong}),kinmem,nbcfails)
+end
+
+function KINGetNumBacktrackOps(kinmem::Ptr{Void},nbacktr::Ptr{Clong})
+    ccall((:KINGetNumBacktrackOps,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong}),kinmem,nbacktr)
+end
+
+function KINGetFuncNorm(kinmem::Ptr{Void},fnorm::Ptr{realtype})
+    ccall((:KINGetFuncNorm,libsundials_kinsol),Cint,(Ptr{Void},Ptr{realtype}),kinmem,fnorm)
+end
+
+function KINGetStepLength(kinmem::Ptr{Void},steplength::Ptr{realtype})
+    ccall((:KINGetStepLength,libsundials_kinsol),Cint,(Ptr{Void},Ptr{realtype}),kinmem,steplength)
+end
+
+function KINGetReturnFlagName(flag::Int)
+    ccall((:KINGetReturnFlagName,libsundials_kinsol),Ptr{UInt8},(Clong,),flag)
+end
+
+function KINFree(kinmem::Vector{Ptr{Void}})
+    ccall((:KINFree,libsundials_kinsol),Void,(Ptr{Ptr{Void}},),kinmem)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/kinsol/kinsol_direct.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function KINDlsSetDenseJacFn(kinmem::Ptr{Void},jac::KINDlsDenseJacFn)
+    ccall((:KINDlsSetDenseJacFn,libsundials_kinsol),Cint,(Ptr{Void},KINDlsDenseJacFn),kinmem,jac)
+end
+
+function KINDlsSetBandJacFn(kinmem::Ptr{Void},jac::KINDlsBandJacFn)
+    ccall((:KINDlsSetBandJacFn,libsundials_kinsol),Cint,(Ptr{Void},KINDlsBandJacFn),kinmem,jac)
+end
+
+function KINDlsGetWorkSpace(kinmem::Ptr{Void},lenrwB::Ptr{Clong},leniwB::Ptr{Clong})
+    ccall((:KINDlsGetWorkSpace,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),kinmem,lenrwB,leniwB)
+end
+
+function KINDlsGetNumJacEvals(kinmem::Ptr{Void},njevalsB::Ptr{Clong})
+    ccall((:KINDlsGetNumJacEvals,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong}),kinmem,njevalsB)
+end
+
+function KINDlsGetNumFuncEvals(kinmem::Ptr{Void},nfevalsB::Ptr{Clong})
+    ccall((:KINDlsGetNumFuncEvals,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong}),kinmem,nfevalsB)
+end
+
+function KINDlsGetLastFlag(kinmem::Ptr{Void},flag::Ptr{Clong})
+    ccall((:KINDlsGetLastFlag,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong}),kinmem,flag)
+end
+
+function KINDlsGetReturnFlagName(flag::Int)
+    ccall((:KINDlsGetReturnFlagName,libsundials_kinsol),Ptr{UInt8},(Clong,),flag)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/kinsol/kinsol_spils.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function KINSpilsSetMaxRestarts(kinmem::Ptr{Void},maxrs::Int)
+    ccall((:KINSpilsSetMaxRestarts,libsundials_kinsol),Cint,(Ptr{Void},Cint),kinmem,maxrs)
+end
+
+function KINSpilsSetPreconditioner(kinmem::Ptr{Void},pset::KINSpilsPrecSetupFn,psolve::KINSpilsPrecSolveFn)
+    ccall((:KINSpilsSetPreconditioner,libsundials_kinsol),Cint,(Ptr{Void},KINSpilsPrecSetupFn,KINSpilsPrecSolveFn),kinmem,pset,psolve)
+end
+
+function KINSpilsSetJacTimesVecFn(kinmem::Ptr{Void},jtv::KINSpilsJacTimesVecFn)
+    ccall((:KINSpilsSetJacTimesVecFn,libsundials_kinsol),Cint,(Ptr{Void},KINSpilsJacTimesVecFn),kinmem,jtv)
+end
+
+function KINSpilsGetWorkSpace(kinmem::Ptr{Void},lenrwSG::Ptr{Clong},leniwSG::Ptr{Clong})
+    ccall((:KINSpilsGetWorkSpace,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),kinmem,lenrwSG,leniwSG)
+end
+
+function KINSpilsGetNumPrecEvals(kinmem::Ptr{Void},npevals::Ptr{Clong})
+    ccall((:KINSpilsGetNumPrecEvals,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong}),kinmem,npevals)
+end
+
+function KINSpilsGetNumPrecSolves(kinmem::Ptr{Void},npsolves::Ptr{Clong})
+    ccall((:KINSpilsGetNumPrecSolves,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong}),kinmem,npsolves)
+end
+
+function KINSpilsGetNumLinIters(kinmem::Ptr{Void},nliters::Ptr{Clong})
+    ccall((:KINSpilsGetNumLinIters,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong}),kinmem,nliters)
+end
+
+function KINSpilsGetNumConvFails(kinmem::Ptr{Void},nlcfails::Ptr{Clong})
+    ccall((:KINSpilsGetNumConvFails,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong}),kinmem,nlcfails)
+end
+
+function KINSpilsGetNumJtimesEvals(kinmem::Ptr{Void},njvevals::Ptr{Clong})
+    ccall((:KINSpilsGetNumJtimesEvals,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong}),kinmem,njvevals)
+end
+
+function KINSpilsGetNumFuncEvals(kinmem::Ptr{Void},nfevalsS::Ptr{Clong})
+    ccall((:KINSpilsGetNumFuncEvals,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong}),kinmem,nfevalsS)
+end
+
+function KINSpilsGetLastFlag(kinmem::Ptr{Void},flag::Ptr{Clong})
+    ccall((:KINSpilsGetLastFlag,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong}),kinmem,flag)
+end
+
+function KINSpilsGetReturnFlagName(flag::Int)
+    ccall((:KINSpilsGetReturnFlagName,libsundials_kinsol),Ptr{UInt8},(Clong,),flag)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/kinsol/kinsol_band.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function KINBand(kinmem::Ptr{Void},N::Int,mupper::Int,mlower::Int)
+    ccall((:KINBand,libsundials_kinsol),Cint,(Ptr{Void},Clong,Clong,Clong),kinmem,N,mupper,mlower)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/kinsol/kinsol_bbdpre.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function KINBBDPrecInit(kinmem::Ptr{Void},Nlocal::Int,mudq::Int,mldq::Int,mukeep::Int,mlkeep::Int,dq_rel_uu::realtype,gloc::KINLocalFn,gcomm::KINCommFn)
+    ccall((:KINBBDPrecInit,libsundials_kinsol),Cint,(Ptr{Void},Clong,Clong,Clong,Clong,Clong,realtype,KINLocalFn,KINCommFn),kinmem,Nlocal,mudq,mldq,mukeep,mlkeep,dq_rel_uu,gloc,gcomm)
+end
+
+function KINBBDPrecGetWorkSpace(kinmem::Ptr{Void},lenrwBBDP::Ptr{Clong},leniwBBDP::Ptr{Clong})
+    ccall((:KINBBDPrecGetWorkSpace,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),kinmem,lenrwBBDP,leniwBBDP)
+end
+
+function KINBBDPrecGetNumGfnEvals(kinmem::Ptr{Void},ngevalsBBDP::Ptr{Clong})
+    ccall((:KINBBDPrecGetNumGfnEvals,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong}),kinmem,ngevalsBBDP)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/kinsol/kinsol_dense.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function KINDense(kinmem::Ptr{Void},N::Int)
+    ccall((:KINDense,libsundials_kinsol),Cint,(Ptr{Void},Clong),kinmem,N)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/kinsol/kinsol_impl.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function KINCreate()
+    ccall((:KINCreate,libsundials_kinsol),Ptr{Void},())
+end
+
+function KINSetErrHandlerFn(kinmem::Ptr{Void},ehfun::KINErrHandlerFn,eh_data::Ptr{Void})
+    ccall((:KINSetErrHandlerFn,libsundials_kinsol),Cint,(Ptr{Void},KINErrHandlerFn,Ptr{Void}),kinmem,ehfun,eh_data)
+end
+
+function KINSetErrFile(kinmem::Ptr{Void},errfp::Ptr{Void})
+    ccall((:KINSetErrFile,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Void}),kinmem,errfp)
+end
+
+function KINSetInfoHandlerFn(kinmem::Ptr{Void},ihfun::KINInfoHandlerFn,ih_data::Ptr{Void})
+    ccall((:KINSetInfoHandlerFn,libsundials_kinsol),Cint,(Ptr{Void},KINInfoHandlerFn,Ptr{Void}),kinmem,ihfun,ih_data)
+end
+
+function KINSetInfoFile(kinmem::Ptr{Void},infofp::Ptr{Void})
+    ccall((:KINSetInfoFile,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Void}),kinmem,infofp)
+end
+
+function KINSetUserData(kinmem::Ptr{Void},user_data::Ptr{Void})
+    ccall((:KINSetUserData,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Void}),kinmem,user_data)
+end
+
+function KINSetPrintLevel(kinmemm::Ptr{Void},printfl::Int)
+    ccall((:KINSetPrintLevel,libsundials_kinsol),Cint,(Ptr{Void},Cint),kinmemm,printfl)
+end
+
+function KINSetNumMaxIters(kinmem::Ptr{Void},mxiter::Int)
+    ccall((:KINSetNumMaxIters,libsundials_kinsol),Cint,(Ptr{Void},Clong),kinmem,mxiter)
+end
+
+function KINSetNoInitSetup(kinmem::Ptr{Void},noInitSetup::Int)
+    ccall((:KINSetNoInitSetup,libsundials_kinsol),Cint,(Ptr{Void},Cint),kinmem,noInitSetup)
+end
+
+function KINSetNoResMon(kinmem::Ptr{Void},noNNIResMon::Int)
+    ccall((:KINSetNoResMon,libsundials_kinsol),Cint,(Ptr{Void},Cint),kinmem,noNNIResMon)
+end
+
+function KINSetMaxSetupCalls(kinmem::Ptr{Void},msbset::Int)
+    ccall((:KINSetMaxSetupCalls,libsundials_kinsol),Cint,(Ptr{Void},Clong),kinmem,msbset)
+end
+
+function KINSetMaxSubSetupCalls(kinmem::Ptr{Void},msbsetsub::Int)
+    ccall((:KINSetMaxSubSetupCalls,libsundials_kinsol),Cint,(Ptr{Void},Clong),kinmem,msbsetsub)
+end
+
+function KINSetEtaForm(kinmem::Ptr{Void},etachoice::Int)
+    ccall((:KINSetEtaForm,libsundials_kinsol),Cint,(Ptr{Void},Cint),kinmem,etachoice)
+end
+
+function KINSetEtaConstValue(kinmem::Ptr{Void},eta::realtype)
+    ccall((:KINSetEtaConstValue,libsundials_kinsol),Cint,(Ptr{Void},realtype),kinmem,eta)
+end
+
+function KINSetEtaParams(kinmem::Ptr{Void},egamma::realtype,ealpha::realtype)
+    ccall((:KINSetEtaParams,libsundials_kinsol),Cint,(Ptr{Void},realtype,realtype),kinmem,egamma,ealpha)
+end
+
+function KINSetResMonParams(kinmem::Ptr{Void},omegamin::realtype,omegamax::realtype)
+    ccall((:KINSetResMonParams,libsundials_kinsol),Cint,(Ptr{Void},realtype,realtype),kinmem,omegamin,omegamax)
+end
+
+function KINSetResMonConstValue(kinmem::Ptr{Void},omegaconst::realtype)
+    ccall((:KINSetResMonConstValue,libsundials_kinsol),Cint,(Ptr{Void},realtype),kinmem,omegaconst)
+end
+
+function KINSetNoMinEps(kinmem::Ptr{Void},noMinEps::Int)
+    ccall((:KINSetNoMinEps,libsundials_kinsol),Cint,(Ptr{Void},Cint),kinmem,noMinEps)
+end
+
+function KINSetMaxNewtonStep(kinmem::Ptr{Void},mxnewtstep::realtype)
+    ccall((:KINSetMaxNewtonStep,libsundials_kinsol),Cint,(Ptr{Void},realtype),kinmem,mxnewtstep)
+end
+
+function KINSetMaxBetaFails(kinmem::Ptr{Void},mxnbcf::Int)
+    ccall((:KINSetMaxBetaFails,libsundials_kinsol),Cint,(Ptr{Void},Clong),kinmem,mxnbcf)
+end
+
+function KINSetRelErrFunc(kinmem::Ptr{Void},relfunc::realtype)
+    ccall((:KINSetRelErrFunc,libsundials_kinsol),Cint,(Ptr{Void},realtype),kinmem,relfunc)
+end
+
+function KINSetFuncNormTol(kinmem::Ptr{Void},fnormtol::realtype)
+    ccall((:KINSetFuncNormTol,libsundials_kinsol),Cint,(Ptr{Void},realtype),kinmem,fnormtol)
+end
+
+function KINSetScaledStepTol(kinmem::Ptr{Void},scsteptol::realtype)
+    ccall((:KINSetScaledStepTol,libsundials_kinsol),Cint,(Ptr{Void},realtype),kinmem,scsteptol)
+end
+
+function KINSetConstraints(kinmem::Ptr{Void},constraints::N_Vector)
+    ccall((:KINSetConstraints,libsundials_kinsol),Cint,(Ptr{Void},N_Vector),kinmem,constraints)
+end
+
+function KINSetSysFunc(kinmem::Ptr{Void},func::KINSysFn)
+    ccall((:KINSetSysFunc,libsundials_kinsol),Cint,(Ptr{Void},KINSysFn),kinmem,func)
+end
+
+function KINInit(kinmem::Ptr{Void},func::KINSysFn,tmpl::N_Vector)
+    ccall((:KINInit,libsundials_kinsol),Cint,(Ptr{Void},KINSysFn,N_Vector),kinmem,func,tmpl)
+end
+
+function KINSol(kinmem::Ptr{Void},uu::N_Vector,strategy::Int,u_scale::N_Vector,f_scale::N_Vector)
+    ccall((:KINSol,libsundials_kinsol),Cint,(Ptr{Void},N_Vector,Cint,N_Vector,N_Vector),kinmem,uu,strategy,u_scale,f_scale)
+end
+
+function KINGetWorkSpace(kinmem::Ptr{Void},lenrw::Ptr{Clong},leniw::Ptr{Clong})
+    ccall((:KINGetWorkSpace,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong},Ptr{Clong}),kinmem,lenrw,leniw)
+end
+
+function KINGetNumNonlinSolvIters(kinmem::Ptr{Void},nniters::Ptr{Clong})
+    ccall((:KINGetNumNonlinSolvIters,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong}),kinmem,nniters)
+end
+
+function KINGetNumFuncEvals(kinmem::Ptr{Void},nfevals::Ptr{Clong})
+    ccall((:KINGetNumFuncEvals,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong}),kinmem,nfevals)
+end
+
+function KINGetNumBetaCondFails(kinmem::Ptr{Void},nbcfails::Ptr{Clong})
+    ccall((:KINGetNumBetaCondFails,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong}),kinmem,nbcfails)
+end
+
+function KINGetNumBacktrackOps(kinmem::Ptr{Void},nbacktr::Ptr{Clong})
+    ccall((:KINGetNumBacktrackOps,libsundials_kinsol),Cint,(Ptr{Void},Ptr{Clong}),kinmem,nbacktr)
+end
+
+function KINGetFuncNorm(kinmem::Ptr{Void},fnorm::Ptr{realtype})
+    ccall((:KINGetFuncNorm,libsundials_kinsol),Cint,(Ptr{Void},Ptr{realtype}),kinmem,fnorm)
+end
+
+function KINGetStepLength(kinmem::Ptr{Void},steplength::Ptr{realtype})
+    ccall((:KINGetStepLength,libsundials_kinsol),Cint,(Ptr{Void},Ptr{realtype}),kinmem,steplength)
+end
+
+function KINGetReturnFlagName(flag::Int)
+    ccall((:KINGetReturnFlagName,libsundials_kinsol),Ptr{UInt8},(Clong,),flag)
+end
+
+function KINFree(kinmem::Vector{Ptr{Void}})
+    ccall((:KINFree,libsundials_kinsol),Void,(Ptr{Ptr{Void}},),kinmem)
+end
+
+function KINErrHandler(error_code::Int,_module::Ptr{UInt8},_function::Ptr{UInt8},msg::Ptr{UInt8},user_data::Ptr{Void})
+    ccall((:KINErrHandler,libsundials_kinsol),Void,(Cint,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},Ptr{Void}),error_code,_module,_function,msg,user_data)
+end
+
+function KINInfoHandler(_module::Ptr{UInt8},_function::Ptr{UInt8},msg::Ptr{UInt8},user_data::Ptr{Void})
+    ccall((:KINInfoHandler,libsundials_kinsol),Void,(Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},Ptr{Void}),_module,_function,msg,user_data)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/kinsol/kinsol_spbcgs.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function KINSpbcg(kinmem::Ptr{Void},maxl::Int)
+    ccall((:KINSpbcg,libsundials_kinsol),Cint,(Ptr{Void},Cint),kinmem,maxl)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/kinsol/kinsol_spgmr.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function KINSpgmr(kinmem::Ptr{Void},maxl::Int)
+    ccall((:KINSpgmr,libsundials_kinsol),Cint,(Ptr{Void},Cint),kinmem,maxl)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/kinsol/kinsol_sptfqmr.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function KINSptfqmr(kinmem::Ptr{Void},maxl::Int)
+    ccall((:KINSptfqmr,libsundials_kinsol),Cint,(Ptr{Void},Cint),kinmem,maxl)
+end

--- a/src/libsundials.jl
+++ b/src/libsundials.jl
@@ -1,125 +1,259 @@
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/sundials/shlib.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
 
-recurs_sym_type(ex::Any) = 
-  (ex==None || typeof(ex)==Symbol || length(ex.args)==1) ? eval(ex) : Expr(ex.head, ex.args[1], recurs_sym_type(ex.args[2]))
-macro c(ret_type, func, arg_types, lib)
-  local _arg_types = Expr(:tuple, [recurs_sym_type(a) for a in arg_types.args]...)
-  local _ret_type = recurs_sym_type(ret_type)
-  local _args_in = Any[ symbol(string('a',x)) for x in 1:length(_arg_types.args) ]
-  local _lib = eval(lib)
-  quote
-    $(esc(func))($(_args_in...)) = ccall( ($(string(func)), $(Expr(:quote, _lib)) ), $_ret_type, $_arg_types, $(_args_in...) )
-  end
+
+function bandGBTRF(a::Ptr{Ptr{realtype}},n::Int,mu::Int,ml::Int,smu::Int,p::Ptr{Clong})
+    ccall((:bandGBTRF,shlib),Clong,(Ptr{Ptr{realtype}},Clong,Clong,Clong,Clong,Ptr{Clong}),a,n,mu,ml,smu,p)
 end
 
-macro ctypedef(fake_t,real_t)
-  real_t = recurs_sym_type(real_t)
-  quote
-    typealias $fake_t $real_t
-  end
+function BandGBTRS(A::DlsMat,p::Ptr{Clong},b::Vector{realtype})
+    ccall((:BandGBTRS,shlib),Void,(DlsMat,Ptr{Clong},Ptr{realtype}),A,p,b)
 end
 
-# header: /usr/local/include/sundials/sundials_band.h
-@ctypedef DlsMat Ptr{:Void}
-@c DlsMat NewDenseMat (:Clong,:Clong) shlib
-@c DlsMat NewBandMat (:Clong,:Clong,:Clong,:Clong) shlib
-@c None DestroyMat (:DlsMat,) shlib
-@c Ptr{:Int32} NewIntArray (:Int32,) shlib
-@c Ptr{:Clong} NewLintArray (:Clong,) shlib
-@c Ptr{:realtype} NewRealArray (:Clong,) shlib
-@c None DestroyArray (Ptr{:None},) shlib
-@c None AddIdentity (:DlsMat,) shlib
-@c None SetToZero (:DlsMat,) shlib
-@c None PrintMat (:DlsMat,) shlib
-@c Ptr{Ptr{:realtype}} newDenseMat (:Clong,:Clong) shlib
-@c Ptr{Ptr{:realtype}} newBandMat (:Clong,:Clong,:Clong) shlib
-@c None destroyMat (Ptr{Ptr{:realtype}},) shlib
-@c Ptr{:Int32} newIntArray (:Int32,) shlib
-@c Ptr{:Clong} newLintArray (:Clong,) shlib
-@c Ptr{:realtype} newRealArray (:Clong,) shlib
-@c None destroyArray (Ptr{:None},) shlib
-@c Clong BandGBTRF (:DlsMat,Ptr{:Clong}) shlib
-@c Clong bandGBTRF (Ptr{Ptr{:realtype}},:Clong,:Clong,:Clong,:Clong,Ptr{:Clong}) shlib
-@c None BandGBTRS (:DlsMat,Ptr{:Clong},Ptr{:realtype}) shlib
-@c None bandGBTRS (Ptr{Ptr{:realtype}},:Clong,:Clong,:Clong,Ptr{:Clong},Ptr{:realtype}) shlib
-@c None BandCopy (:DlsMat,:DlsMat,:Clong,:Clong) shlib
-@c None bandCopy (Ptr{Ptr{:realtype}},Ptr{Ptr{:realtype}},:Clong,:Clong,:Clong,:Clong,:Clong) shlib
-@c None BandScale (:realtype,:DlsMat) shlib
-@c None bandScale (:realtype,Ptr{Ptr{:realtype}},:Clong,:Clong,:Clong,:Clong) shlib
-@c None bandAddIdentity (Ptr{Ptr{:realtype}},:Clong,:Clong) shlib
+function bandGBTRS(a::Ptr{Ptr{realtype}},n::Int,smu::Int,ml::Int,p::Ptr{Clong},b::Vector{realtype})
+    ccall((:bandGBTRS,shlib),Void,(Ptr{Ptr{realtype}},Clong,Clong,Clong,Ptr{Clong},Ptr{realtype}),a,n,smu,ml,p,b)
+end
 
-# header: /usr/local/include/sundials/sundials_config.h
+function BandCopy(A::DlsMat,B::DlsMat,copymu::Int,copyml::Int)
+    ccall((:BandCopy,shlib),Void,(DlsMat,DlsMat,Clong,Clong),A,B,copymu,copyml)
+end
 
-# header: /usr/local/include/sundials/sundials_dense.h
-@c Clong DenseGETRF (:DlsMat,Ptr{:Clong}) shlib
-@c None DenseGETRS (:DlsMat,Ptr{:Clong},Ptr{:realtype}) shlib
-@c Clong denseGETRF (Ptr{Ptr{:realtype}},:Clong,:Clong,Ptr{:Clong}) shlib
-@c None denseGETRS (Ptr{Ptr{:realtype}},:Clong,Ptr{:Clong},Ptr{:realtype}) shlib
-@c Clong DensePOTRF (:DlsMat,) shlib
-@c None DensePOTRS (:DlsMat,Ptr{:realtype}) shlib
-@c Clong densePOTRF (Ptr{Ptr{:realtype}},:Clong) shlib
-@c None densePOTRS (Ptr{Ptr{:realtype}},:Clong,Ptr{:realtype}) shlib
-@c Int32 DenseGEQRF (:DlsMat,Ptr{:realtype},Ptr{:realtype}) shlib
-@c Int32 DenseORMQR (:DlsMat,Ptr{:realtype},Ptr{:realtype},Ptr{:realtype},Ptr{:realtype}) shlib
-@c Int32 denseGEQRF (Ptr{Ptr{:realtype}},:Clong,:Clong,Ptr{:realtype},Ptr{:realtype}) shlib
-@c Int32 denseORMQR (Ptr{Ptr{:realtype}},:Clong,:Clong,Ptr{:realtype},Ptr{:realtype},Ptr{:realtype},Ptr{:realtype}) shlib
-@c None DenseCopy (:DlsMat,:DlsMat) shlib
-@c None denseCopy (Ptr{Ptr{:realtype}},Ptr{Ptr{:realtype}},:Clong,:Clong) shlib
-@c None DenseScale (:realtype,:DlsMat) shlib
-@c None denseScale (:realtype,Ptr{Ptr{:realtype}},:Clong,:Clong) shlib
-@c None denseAddIdentity (Ptr{Ptr{:realtype}},:Clong) shlib
+function bandCopy(a::Ptr{Ptr{realtype}},b::Ptr{Ptr{realtype}},n::Int,a_smu::Int,b_smu::Int,copymu::Int,copyml::Int)
+    ccall((:bandCopy,shlib),Void,(Ptr{Ptr{realtype}},Ptr{Ptr{realtype}},Clong,Clong,Clong,Clong,Clong),a,b,n,a_smu,b_smu,copymu,copyml)
+end
 
-# header: /usr/local/include/sundials/sundials_direct.h
+function BandScale(c::realtype,A::DlsMat)
+    ccall((:BandScale,shlib),Void,(realtype,DlsMat),c,A)
+end
 
-# header: /usr/local/include/sundials/sundials_fnvector.h
+function bandScale(c::realtype,a::Ptr{Ptr{realtype}},n::Int,mu::Int,ml::Int,smu::Int)
+    ccall((:bandScale,shlib),Void,(realtype,Ptr{Ptr{realtype}},Clong,Clong,Clong,Clong),c,a,n,mu,ml,smu)
+end
 
-# header: /usr/local/include/sundials/sundials_iterative.h
-# enum ANONYMOUS
-@ctypedef ANONYMOUS Uint32
-const PREC_NONE = 0
-const PREC_LEFT = 1
-const PREC_RIGHT = 2
-const PREC_BOTH = 3
-# end
-# enum ATimesFn
-@ctypedef ATimesFn Uint32
-const MODIFIED_GS = 1
-const CLASSICAL_GS = 2
-# end
-@ctypedef PSolveFn Ptr{:Void}
-@c Int32 ModifiedGS (Ptr{:N_Vector},Ptr{Ptr{:realtype}},:Int32,:Int32,Ptr{:realtype}) shlib
-@c Int32 ClassicalGS (Ptr{:N_Vector},Ptr{Ptr{:realtype}},:Int32,:Int32,Ptr{:realtype},:N_Vector,Ptr{:realtype}) shlib
-@c Int32 QRfact (:Int32,Ptr{Ptr{:realtype}},Ptr{:realtype},:Int32) shlib
-@c Int32 QRsol (:Int32,Ptr{Ptr{:realtype}},Ptr{:realtype},Ptr{:realtype}) shlib
+function bandAddIdentity(a::Ptr{Ptr{realtype}},n::Int,smu::Int)
+    ccall((:bandAddIdentity,shlib),Void,(Ptr{Ptr{realtype}},Clong,Clong),a,n,smu)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/sundials/sundials_config.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
 
-# header: /usr/local/include/sundials/sundials_math.h
-@c realtype RPowerI (:realtype,:Int32) shlib
-@c realtype RPowerR (:realtype,:realtype) shlib
-@c realtype RSqrt (:realtype,) shlib
-@c realtype RAbs (:realtype,) shlib
-@c realtype RExp (:realtype,) shlib
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/sundials/sundials_dense.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
 
-# header: /usr/local/include/sundials/sundials_nvector.h
+function DenseGETRF(A::DlsMat,p::Ptr{Clong})
+    ccall((:DenseGETRF,shlib),Clong,(DlsMat,Ptr{Clong}),A,p)
+end
 
-# header: /usr/local/include/sundials/sundials_spbcgs.h
-@ctypedef SpbcgMemRec Void
-@ctypedef SpbcgMem Ptr{:Void}
-@c SpbcgMem SpbcgMalloc (:Int32,:N_Vector) shlib
-@c Int32 SpbcgSolve (:SpbcgMem,Ptr{:None},:N_Vector,:N_Vector,:Int32,:realtype,Ptr{:None},:N_Vector,:N_Vector,:ATimesFn,:PSolveFn,Ptr{:realtype},Ptr{:Int32},Ptr{:Int32}) shlib
-@c None SpbcgFree (:SpbcgMem,) shlib
+function DenseGETRS(A::DlsMat,p::Ptr{Clong},b::Vector{realtype})
+    ccall((:DenseGETRS,shlib),Void,(DlsMat,Ptr{Clong},Ptr{realtype}),A,p,b)
+end
 
-# header: /usr/local/include/sundials/sundials_spgmr.h
-@ctypedef SpgmrMemRec Void
-@ctypedef SpgmrMem Ptr{:Void}
-@c SpgmrMem SpgmrMalloc (:Int32,:N_Vector) shlib
-@c Int32 SpgmrSolve (:SpgmrMem,Ptr{:None},:N_Vector,:N_Vector,:Int32,:Int32,:realtype,:Int32,Ptr{:None},:N_Vector,:N_Vector,:ATimesFn,:PSolveFn,Ptr{:realtype},Ptr{:Int32},Ptr{:Int32}) shlib
-@c None SpgmrFree (:SpgmrMem,) shlib
+function denseGETRF(a::Ptr{Ptr{realtype}},m::Int,n::Int,p::Ptr{Clong})
+    ccall((:denseGETRF,shlib),Clong,(Ptr{Ptr{realtype}},Clong,Clong,Ptr{Clong}),a,m,n,p)
+end
 
-# header: /usr/local/include/sundials/sundials_sptfqmr.h
-@ctypedef SptfqmrMemRec Void
-@ctypedef SptfqmrMem Ptr{:Void}
-@c SptfqmrMem SptfqmrMalloc (:Int32,:N_Vector) shlib
-@c Int32 SptfqmrSolve (:SptfqmrMem,Ptr{:None},:N_Vector,:N_Vector,:Int32,:realtype,Ptr{:None},:N_Vector,:N_Vector,:ATimesFn,:PSolveFn,Ptr{:realtype},Ptr{:Int32},Ptr{:Int32}) shlib
-@c None SptfqmrFree (:SptfqmrMem,) shlib
+function denseGETRS(a::Ptr{Ptr{realtype}},n::Int,p::Ptr{Clong},b::Vector{realtype})
+    ccall((:denseGETRS,shlib),Void,(Ptr{Ptr{realtype}},Clong,Ptr{Clong},Ptr{realtype}),a,n,p,b)
+end
 
-# header: /usr/local/include/sundials/sundials_types.h
+function DensePOTRF(A::DlsMat)
+    ccall((:DensePOTRF,shlib),Clong,(DlsMat,),A)
+end
 
+function DensePOTRS(A::DlsMat,b::Vector{realtype})
+    ccall((:DensePOTRS,shlib),Void,(DlsMat,Ptr{realtype}),A,b)
+end
+
+function densePOTRF(a::Ptr{Ptr{realtype}},m::Int)
+    ccall((:densePOTRF,shlib),Clong,(Ptr{Ptr{realtype}},Clong),a,m)
+end
+
+function densePOTRS(a::Ptr{Ptr{realtype}},m::Int,b::Vector{realtype})
+    ccall((:densePOTRS,shlib),Void,(Ptr{Ptr{realtype}},Clong,Ptr{realtype}),a,m,b)
+end
+
+function DenseGEQRF(A::DlsMat,beta::Vector{realtype},wrk::Vector{realtype})
+    ccall((:DenseGEQRF,shlib),Cint,(DlsMat,Ptr{realtype},Ptr{realtype}),A,beta,wrk)
+end
+
+function DenseORMQR(A::DlsMat,beta::Vector{realtype},vn::Vector{realtype},vm::Vector{realtype},wrk::Vector{realtype})
+    ccall((:DenseORMQR,shlib),Cint,(DlsMat,Ptr{realtype},Ptr{realtype},Ptr{realtype},Ptr{realtype}),A,beta,vn,vm,wrk)
+end
+
+function denseGEQRF(a::Ptr{Ptr{realtype}},m::Int,n::Int,beta::Vector{realtype},v::Vector{realtype})
+    ccall((:denseGEQRF,shlib),Cint,(Ptr{Ptr{realtype}},Clong,Clong,Ptr{realtype},Ptr{realtype}),a,m,n,beta,v)
+end
+
+function denseORMQR(a::Ptr{Ptr{realtype}},m::Int,n::Int,beta::Vector{realtype},v::Vector{realtype},w::Vector{realtype},wrk::Vector{realtype})
+    ccall((:denseORMQR,shlib),Cint,(Ptr{Ptr{realtype}},Clong,Clong,Ptr{realtype},Ptr{realtype},Ptr{realtype},Ptr{realtype}),a,m,n,beta,v,w,wrk)
+end
+
+function DenseCopy(A::DlsMat,B::DlsMat)
+    ccall((:DenseCopy,shlib),Void,(DlsMat,DlsMat),A,B)
+end
+
+function denseCopy(a::Ptr{Ptr{realtype}},b::Ptr{Ptr{realtype}},m::Int,n::Int)
+    ccall((:denseCopy,shlib),Void,(Ptr{Ptr{realtype}},Ptr{Ptr{realtype}},Clong,Clong),a,b,m,n)
+end
+
+function DenseScale(c::realtype,A::DlsMat)
+    ccall((:DenseScale,shlib),Void,(realtype,DlsMat),c,A)
+end
+
+function denseScale(c::realtype,a::Ptr{Ptr{realtype}},m::Int,n::Int)
+    ccall((:denseScale,shlib),Void,(realtype,Ptr{Ptr{realtype}},Clong,Clong),c,a,m,n)
+end
+
+function denseAddIdentity(a::Ptr{Ptr{realtype}},n::Int)
+    ccall((:denseAddIdentity,shlib),Void,(Ptr{Ptr{realtype}},Clong),a,n)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/sundials/sundials_direct.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+
+function NewDenseMat(M::Int,N::Int)
+    ccall((:NewDenseMat,shlib),DlsMat,(Clong,Clong),M,N)
+end
+
+function NewBandMat(N::Int,mu::Int,ml::Int,smu::Int)
+    ccall((:NewBandMat,shlib),DlsMat,(Clong,Clong,Clong,Clong),N,mu,ml,smu)
+end
+
+function DestroyMat(A::DlsMat)
+    ccall((:DestroyMat,shlib),Void,(DlsMat,),A)
+end
+
+function NewIntArray(N::Int)
+    ccall((:NewIntArray,shlib),Ptr{Cint},(Cint,),N)
+end
+
+function NewLintArray(N::Int)
+    ccall((:NewLintArray,shlib),Ptr{Clong},(Clong,),N)
+end
+
+function NewRealArray(N::Int)
+    ccall((:NewRealArray,shlib),Ptr{realtype},(Clong,),N)
+end
+
+function DestroyArray(p::Ptr{Void})
+    ccall((:DestroyArray,shlib),Void,(Ptr{Void},),p)
+end
+
+function AddIdentity(A::DlsMat)
+    ccall((:AddIdentity,shlib),Void,(DlsMat,),A)
+end
+
+function SetToZero(A::DlsMat)
+    ccall((:SetToZero,shlib),Void,(DlsMat,),A)
+end
+
+function PrintMat(A::DlsMat)
+    ccall((:PrintMat,shlib),Void,(DlsMat,),A)
+end
+
+function newDenseMat(m::Int,n::Int)
+    ccall((:newDenseMat,shlib),Ptr{Ptr{realtype}},(Clong,Clong),m,n)
+end
+
+function newBandMat(n::Int,smu::Int,ml::Int)
+    ccall((:newBandMat,shlib),Ptr{Ptr{realtype}},(Clong,Clong,Clong),n,smu,ml)
+end
+
+function destroyMat(a::Ptr{Ptr{realtype}})
+    ccall((:destroyMat,shlib),Void,(Ptr{Ptr{realtype}},),a)
+end
+
+function newIntArray(n::Int)
+    ccall((:newIntArray,shlib),Ptr{Cint},(Cint,),n)
+end
+
+function newLintArray(n::Int)
+    ccall((:newLintArray,shlib),Ptr{Clong},(Clong,),n)
+end
+
+function newRealArray(m::Int)
+    ccall((:newRealArray,shlib),Ptr{realtype},(Clong,),m)
+end
+
+function destroyArray(v::Ptr{Void})
+    ccall((:destroyArray,shlib),Void,(Ptr{Void},),v)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/sundials/sundials_iterative.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function ModifiedGS(v::Ptr{N_Vector},h::Ptr{Ptr{realtype}},k::Int,p::Int,new_vk_norm::Vector{realtype})
+    ccall((:ModifiedGS,shlib),Cint,(Ptr{N_Vector},Ptr{Ptr{realtype}},Cint,Cint,Ptr{realtype}),v,h,k,p,new_vk_norm)
+end
+
+function ClassicalGS(v::Ptr{N_Vector},h::Ptr{Ptr{realtype}},k::Int,p::Int,new_vk_norm::Vector{realtype},temp::N_Vector,s::Vector{realtype})
+    ccall((:ClassicalGS,shlib),Cint,(Ptr{N_Vector},Ptr{Ptr{realtype}},Cint,Cint,Ptr{realtype},N_Vector,Ptr{realtype}),v,h,k,p,new_vk_norm,temp,s)
+end
+
+function QRfact(n::Int,h::Ptr{Ptr{realtype}},q::Vector{realtype},job::Int)
+    ccall((:QRfact,shlib),Cint,(Cint,Ptr{Ptr{realtype}},Ptr{realtype},Cint),n,h,q,job)
+end
+
+function QRsol(n::Int,h::Ptr{Ptr{realtype}},q::Vector{realtype},b::Vector{realtype})
+    ccall((:QRsol,shlib),Cint,(Cint,Ptr{Ptr{realtype}},Ptr{realtype},Ptr{realtype}),n,h,q,b)
+end
+
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/sundials/sundials_spbcgs.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/sundials/sundials_spgmr.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function SpgmrMalloc(l_max::Int,vec_tmpl::N_Vector)
+    ccall((:SpgmrMalloc,shlib),SpgmrMem,(Cint,N_Vector),l_max,vec_tmpl)
+end
+
+function SpgmrSolve(mem::SpgmrMem,A_data::Ptr{Void},x::N_Vector,b::N_Vector,pretype::Int,gstype::Int,delta::realtype,max_restarts::Int,P_data::Ptr{Void},s1::N_Vector,s2::N_Vector,atimes::ATimesFn,psolve::PSolveFn,res_norm::Vector{realtype},nli::Ptr{Cint},nps::Ptr{Cint})
+    ccall((:SpgmrSolve,shlib),Cint,(SpgmrMem,Ptr{Void},N_Vector,N_Vector,Cint,Cint,realtype,Cint,Ptr{Void},N_Vector,N_Vector,ATimesFn,PSolveFn,Ptr{realtype},Ptr{Cint},Ptr{Cint}),mem,A_data,x,b,pretype,gstype,delta,max_restarts,P_data,s1,s2,atimes,psolve,res_norm,nli,nps)
+end
+
+function SpgmrFree(mem::SpgmrMem)
+    ccall((:SpgmrFree,shlib),Void,(SpgmrMem,),mem)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/sundials/sundials_sptfqmr.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+function SptfqmrMalloc(l_max::Int,vec_tmpl::N_Vector)
+    ccall((:SptfqmrMalloc,shlib),SptfqmrMem,(Cint,N_Vector),l_max,vec_tmpl)
+end
+
+function SptfqmrSolve(mem::SptfqmrMem,A_data::Ptr{Void},x::N_Vector,b::N_Vector,pretype::Int,delta::realtype,P_data::Ptr{Void},sx::N_Vector,sb::N_Vector,atimes::ATimesFn,psolve::PSolveFn,res_norm::Vector{realtype},nli::Ptr{Cint},nps::Ptr{Cint})
+    ccall((:SptfqmrSolve,shlib),Cint,(SptfqmrMem,Ptr{Void},N_Vector,N_Vector,Cint,realtype,Ptr{Void},N_Vector,N_Vector,ATimesFn,PSolveFn,Ptr{realtype},Ptr{Cint},Ptr{Cint}),mem,A_data,x,b,pretype,delta,P_data,sx,sb,atimes,psolve,res_norm,nli,nps)
+end
+
+function SptfqmrFree(mem::SptfqmrMem)
+    ccall((:SptfqmrFree,shlib),Void,(SptfqmrMem,),mem)
+end
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/sundials/sundials_types.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/sundials/sundials_fnvector.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/sundials/sundials_math.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+
+function RPowerI(base::realtype,exponent::Int)
+    ccall((:RPowerI,shlib),realtype,(realtype,Cint),base,exponent)
+end
+
+function RPowerR(base::realtype,exponent::realtype)
+    ccall((:RPowerR,shlib),realtype,(realtype,realtype),base,exponent)
+end
+
+function RSqrt(x::realtype)
+    ccall((:RSqrt,shlib),realtype,(realtype,),x)
+end
+
+function RAbs(x::realtype)
+    ccall((:RAbs,shlib),realtype,(realtype,),x)
+end
+
+function RExp(x::realtype)
+    ccall((:RExp,shlib),realtype,(realtype,),x)
+end

--- a/src/nvector.jl
+++ b/src/nvector.jl
@@ -1,122 +1,243 @@
+# Julia wrapper for header: /Users/jgoldfar/.julia/v0.4/Sundials/deps/usr/include/nvector/shlib.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
 
-recurs_sym_type(ex::Any) = 
-  (ex==None || typeof(ex)==Symbol || length(ex.args)==1) ? eval(ex) : Expr(ex.head, ex.args[1], recurs_sym_type(ex.args[2]))
-macro c(ret_type, func, arg_types, lib)
-  local _arg_types = Expr(:tuple, [recurs_sym_type(a) for a in arg_types.args]...)
-  local _ret_type = recurs_sym_type(ret_type)
-  local _args_in = Any[ symbol(string('a',x)) for x in 1:length(_arg_types.args) ]
-  local _lib = eval(lib)
-  quote
-    $(esc(func))($(_args_in...)) = ccall( ($(string(func)), $(Expr(:quote, _lib)) ), $_ret_type, $_arg_types, $(_args_in...) )
-  end
+
+function N_VClone(w::N_Vector)
+    ccall((:N_VClone,libsundials_nvecserial),N_Vector,(N_Vector,),w)
 end
 
-macro ctypedef(fake_t,real_t)
-  real_t = recurs_sym_type(real_t)
-  quote
-    typealias $fake_t $real_t
-  end
+function N_VCloneEmpty(w::N_Vector)
+    ccall((:N_VCloneEmpty,libsundials_nvecserial),N_Vector,(N_Vector,),w)
 end
 
-# header: /usr/local/include/nvector/nvector_parallel.h
-@ctypedef realtype Float64
-@ctypedef N_Vector_Ops Ptr{:Void}
-@ctypedef N_Vector Ptr{:Void}
-@ctypedef N_Vector_S Ptr{:N_Vector}
-@c N_Vector N_VClone (:N_Vector,) shlib
-@c N_Vector N_VCloneEmpty (:N_Vector,) shlib
-@c None N_VDestroy (:N_Vector,) shlib
-@c None N_VSpace (:N_Vector,Ptr{:Clong},Ptr{:Clong}) shlib
-@c Ptr{:realtype} N_VGetArrayPointer (:N_Vector,) shlib
-@c None N_VSetArrayPointer (Ptr{:realtype},:N_Vector) shlib
-@c None N_VLinearSum (:realtype,:N_Vector,:realtype,:N_Vector,:N_Vector) shlib
-@c None N_VConst (:realtype,:N_Vector) shlib
-@c None N_VProd (:N_Vector,:N_Vector,:N_Vector) shlib
-@c None N_VDiv (:N_Vector,:N_Vector,:N_Vector) shlib
-@c None N_VScale (:realtype,:N_Vector,:N_Vector) shlib
-@c None N_VAbs (:N_Vector,:N_Vector) shlib
-@c None N_VInv (:N_Vector,:N_Vector) shlib
-@c None N_VAddConst (:N_Vector,:realtype,:N_Vector) shlib
-@c realtype N_VDotProd (:N_Vector,:N_Vector) shlib
-@c realtype N_VMaxNorm (:N_Vector,) shlib
-@c realtype N_VWrmsNorm (:N_Vector,:N_Vector) shlib
-@c realtype N_VWrmsNormMask (:N_Vector,:N_Vector,:N_Vector) shlib
-@c realtype N_VMin (:N_Vector,) shlib
-@c realtype N_VWL2Norm (:N_Vector,:N_Vector) shlib
-@c realtype N_VL1Norm (:N_Vector,) shlib
-@c None N_VCompare (:realtype,:N_Vector,:N_Vector) shlib
-@c Int32 N_VInvTest (:N_Vector,:N_Vector) shlib
-@c Int32 N_VConstrMask (:N_Vector,:N_Vector,:N_Vector) shlib
-@c realtype N_VMinQuotient (:N_Vector,:N_Vector) shlib
-@c Ptr{:N_Vector} N_VCloneEmptyVectorArray (:Int32,:N_Vector) shlib
-@c Ptr{:N_Vector} N_VCloneVectorArray (:Int32,:N_Vector) shlib
-@c None N_VDestroyVectorArray (Ptr{:N_Vector},:Int32) shlib
-@ctypedef N_VectorContent_Parallel Ptr{:Void}
-@c N_Vector N_VNew_Parallel (:Int32,:Clong,:Clong) shlib
-@c N_Vector N_VNewEmpty_Parallel (:Int32,:Clong,:Clong) shlib
-@c N_Vector N_VMake_Parallel (:Int32,:Clong,:Clong,Ptr{:realtype}) shlib
-@c Ptr{:N_Vector} N_VCloneVectorArray_Parallel (:Int32,:N_Vector) shlib
-@c Ptr{:N_Vector} N_VCloneVectorArrayEmpty_Parallel (:Int32,:N_Vector) shlib
-@c None N_VDestroyVectorArray_Parallel (Ptr{:N_Vector},:Int32) shlib
-@c None N_VPrint_Parallel (:N_Vector,) shlib
-@c N_Vector N_VCloneEmpty_Parallel (:N_Vector,) shlib
-@c N_Vector N_VClone_Parallel (:N_Vector,) shlib
-@c None N_VDestroy_Parallel (:N_Vector,) shlib
-@c None N_VSpace_Parallel (:N_Vector,Ptr{:Clong},Ptr{:Clong}) shlib
-@c Ptr{:realtype} N_VGetArrayPointer_Parallel (:N_Vector,) shlib
-@c None N_VSetArrayPointer_Parallel (Ptr{:realtype},:N_Vector) shlib
-@c None N_VLinearSum_Parallel (:realtype,:N_Vector,:realtype,:N_Vector,:N_Vector) shlib
-@c None N_VConst_Parallel (:realtype,:N_Vector) shlib
-@c None N_VProd_Parallel (:N_Vector,:N_Vector,:N_Vector) shlib
-@c None N_VDiv_Parallel (:N_Vector,:N_Vector,:N_Vector) shlib
-@c None N_VScale_Parallel (:realtype,:N_Vector,:N_Vector) shlib
-@c None N_VAbs_Parallel (:N_Vector,:N_Vector) shlib
-@c None N_VInv_Parallel (:N_Vector,:N_Vector) shlib
-@c None N_VAddConst_Parallel (:N_Vector,:realtype,:N_Vector) shlib
-@c realtype N_VDotProd_Parallel (:N_Vector,:N_Vector) shlib
-@c realtype N_VMaxNorm_Parallel (:N_Vector,) shlib
-@c realtype N_VWrmsNorm_Parallel (:N_Vector,:N_Vector) shlib
-@c realtype N_VWrmsNormMask_Parallel (:N_Vector,:N_Vector,:N_Vector) shlib
-@c realtype N_VMin_Parallel (:N_Vector,) shlib
-@c realtype N_VWL2Norm_Parallel (:N_Vector,:N_Vector) shlib
-@c realtype N_VL1Norm_Parallel (:N_Vector,) shlib
-@c None N_VCompare_Parallel (:realtype,:N_Vector,:N_Vector) shlib
-@c Int32 N_VInvTest_Parallel (:N_Vector,:N_Vector) shlib
-@c Int32 N_VConstrMask_Parallel (:N_Vector,:N_Vector,:N_Vector) shlib
-@c realtype N_VMinQuotient_Parallel (:N_Vector,:N_Vector) shlib
+function N_VDestroy(v::N_Vector)
+    ccall((:N_VDestroy,libsundials_nvecserial),Void,(N_Vector,),v)
+end
 
-# header: /usr/local/include/nvector/nvector_serial.h
-@ctypedef N_VectorContent_Serial Ptr{:Void}
-@c N_Vector N_VNew_Serial (:Clong,) shlib
-@c N_Vector N_VNewEmpty_Serial (:Clong,) shlib
-@c N_Vector N_VMake_Serial (:Clong,Ptr{:realtype}) shlib
-@c Ptr{:N_Vector} N_VCloneVectorArray_Serial (:Int32,:N_Vector) shlib
-@c Ptr{:N_Vector} N_VCloneVectorArrayEmpty_Serial (:Int32,:N_Vector) shlib
-@c None N_VDestroyVectorArray_Serial (Ptr{:N_Vector},:Int32) shlib
-@c None N_VPrint_Serial (:N_Vector,) shlib
-@c N_Vector N_VCloneEmpty_Serial (:N_Vector,) shlib
-@c N_Vector N_VClone_Serial (:N_Vector,) shlib
-@c None N_VDestroy_Serial (:N_Vector,) shlib
-@c None N_VSpace_Serial (:N_Vector,Ptr{:Clong},Ptr{:Clong}) shlib
-@c Ptr{:realtype} N_VGetArrayPointer_Serial (:N_Vector,) shlib
-@c None N_VSetArrayPointer_Serial (Ptr{:realtype},:N_Vector) shlib
-@c None N_VLinearSum_Serial (:realtype,:N_Vector,:realtype,:N_Vector,:N_Vector) shlib
-@c None N_VConst_Serial (:realtype,:N_Vector) shlib
-@c None N_VProd_Serial (:N_Vector,:N_Vector,:N_Vector) shlib
-@c None N_VDiv_Serial (:N_Vector,:N_Vector,:N_Vector) shlib
-@c None N_VScale_Serial (:realtype,:N_Vector,:N_Vector) shlib
-@c None N_VAbs_Serial (:N_Vector,:N_Vector) shlib
-@c None N_VInv_Serial (:N_Vector,:N_Vector) shlib
-@c None N_VAddConst_Serial (:N_Vector,:realtype,:N_Vector) shlib
-@c realtype N_VDotProd_Serial (:N_Vector,:N_Vector) shlib
-@c realtype N_VMaxNorm_Serial (:N_Vector,) shlib
-@c realtype N_VWrmsNorm_Serial (:N_Vector,:N_Vector) shlib
-@c realtype N_VWrmsNormMask_Serial (:N_Vector,:N_Vector,:N_Vector) shlib
-@c realtype N_VMin_Serial (:N_Vector,) shlib
-@c realtype N_VWL2Norm_Serial (:N_Vector,:N_Vector) shlib
-@c realtype N_VL1Norm_Serial (:N_Vector,) shlib
-@c None N_VCompare_Serial (:realtype,:N_Vector,:N_Vector) shlib
-@c Int32 N_VInvTest_Serial (:N_Vector,:N_Vector) shlib
-@c Int32 N_VConstrMask_Serial (:N_Vector,:N_Vector,:N_Vector) shlib
-@c realtype N_VMinQuotient_Serial (:N_Vector,:N_Vector) shlib
+function N_VSpace(v::N_Vector,lrw::Ptr{Clong},liw::Ptr{Clong})
+    ccall((:N_VSpace,libsundials_nvecserial),Void,(N_Vector,Ptr{Clong},Ptr{Clong}),v,lrw,liw)
+end
 
+function N_VGetArrayPointer(v::N_Vector)
+    ccall((:N_VGetArrayPointer,libsundials_nvecserial),Ptr{realtype},(N_Vector,),v)
+end
+
+function N_VSetArrayPointer(v_data::Vector{realtype},v::N_Vector)
+    ccall((:N_VSetArrayPointer,libsundials_nvecserial),Void,(Ptr{realtype},N_Vector),v_data,v)
+end
+
+function N_VLinearSum(a::realtype,x::N_Vector,b::realtype,y::N_Vector,z::N_Vector)
+    ccall((:N_VLinearSum,libsundials_nvecserial),Void,(realtype,N_Vector,realtype,N_Vector,N_Vector),a,x,b,y,z)
+end
+
+function N_VConst(c::realtype,z::N_Vector)
+    ccall((:N_VConst,libsundials_nvecserial),Void,(realtype,N_Vector),c,z)
+end
+
+function N_VProd(x::N_Vector,y::N_Vector,z::N_Vector)
+    ccall((:N_VProd,libsundials_nvecserial),Void,(N_Vector,N_Vector,N_Vector),x,y,z)
+end
+
+function N_VDiv(x::N_Vector,y::N_Vector,z::N_Vector)
+    ccall((:N_VDiv,libsundials_nvecserial),Void,(N_Vector,N_Vector,N_Vector),x,y,z)
+end
+
+function N_VScale(c::realtype,x::N_Vector,z::N_Vector)
+    ccall((:N_VScale,libsundials_nvecserial),Void,(realtype,N_Vector,N_Vector),c,x,z)
+end
+
+function N_VAbs(x::N_Vector,z::N_Vector)
+    ccall((:N_VAbs,libsundials_nvecserial),Void,(N_Vector,N_Vector),x,z)
+end
+
+function N_VInv(x::N_Vector,z::N_Vector)
+    ccall((:N_VInv,libsundials_nvecserial),Void,(N_Vector,N_Vector),x,z)
+end
+
+function N_VAddConst(x::N_Vector,b::realtype,z::N_Vector)
+    ccall((:N_VAddConst,libsundials_nvecserial),Void,(N_Vector,realtype,N_Vector),x,b,z)
+end
+
+function N_VDotProd(x::N_Vector,y::N_Vector)
+    ccall((:N_VDotProd,libsundials_nvecserial),realtype,(N_Vector,N_Vector),x,y)
+end
+
+function N_VMaxNorm(x::N_Vector)
+    ccall((:N_VMaxNorm,libsundials_nvecserial),realtype,(N_Vector,),x)
+end
+
+function N_VWrmsNorm(x::N_Vector,w::N_Vector)
+    ccall((:N_VWrmsNorm,libsundials_nvecserial),realtype,(N_Vector,N_Vector),x,w)
+end
+
+function N_VWrmsNormMask(x::N_Vector,w::N_Vector,id::N_Vector)
+    ccall((:N_VWrmsNormMask,libsundials_nvecserial),realtype,(N_Vector,N_Vector,N_Vector),x,w,id)
+end
+
+function N_VMin(x::N_Vector)
+    ccall((:N_VMin,libsundials_nvecserial),realtype,(N_Vector,),x)
+end
+
+function N_VWL2Norm(x::N_Vector,w::N_Vector)
+    ccall((:N_VWL2Norm,libsundials_nvecserial),realtype,(N_Vector,N_Vector),x,w)
+end
+
+function N_VL1Norm(x::N_Vector)
+    ccall((:N_VL1Norm,libsundials_nvecserial),realtype,(N_Vector,),x)
+end
+
+function N_VCompare(c::realtype,x::N_Vector,z::N_Vector)
+    ccall((:N_VCompare,libsundials_nvecserial),Void,(realtype,N_Vector,N_Vector),c,x,z)
+end
+
+function N_VInvTest(x::N_Vector,z::N_Vector)
+    ccall((:N_VInvTest,libsundials_nvecserial),Cint,(N_Vector,N_Vector),x,z)
+end
+
+function N_VConstrMask(c::N_Vector,x::N_Vector,m::N_Vector)
+    ccall((:N_VConstrMask,libsundials_nvecserial),Cint,(N_Vector,N_Vector,N_Vector),c,x,m)
+end
+
+function N_VMinQuotient(num::N_Vector,denom::N_Vector)
+    ccall((:N_VMinQuotient,libsundials_nvecserial),realtype,(N_Vector,N_Vector),num,denom)
+end
+
+function N_VCloneEmptyVectorArray(count::Int,w::N_Vector)
+    ccall((:N_VCloneEmptyVectorArray,libsundials_nvecserial),Ptr{N_Vector},(Cint,N_Vector),count,w)
+end
+
+function N_VCloneVectorArray(count::Int,w::N_Vector)
+    ccall((:N_VCloneVectorArray,libsundials_nvecserial),Ptr{N_Vector},(Cint,N_Vector),count,w)
+end
+
+function N_VDestroyVectorArray(vs::Ptr{N_Vector},count::Int)
+    ccall((:N_VDestroyVectorArray,libsundials_nvecserial),Void,(Ptr{N_Vector},Cint),vs,count)
+end
+
+function N_VNew_Serial(vec_length::Int)
+    ccall((:N_VNew_Serial,libsundials_nvecserial),N_Vector,(Clong,),vec_length)
+end
+
+function N_VNewEmpty_Serial(vec_length::Int)
+    ccall((:N_VNewEmpty_Serial,libsundials_nvecserial),N_Vector,(Clong,),vec_length)
+end
+
+function N_VMake_Serial(vec_length::Int,v_data::Vector{realtype})
+    ccall((:N_VMake_Serial,libsundials_nvecserial),N_Vector,(Clong,Ptr{realtype}),vec_length,v_data)
+end
+
+function N_VCloneVectorArray_Serial(count::Int,w::N_Vector)
+    ccall((:N_VCloneVectorArray_Serial,libsundials_nvecserial),Ptr{N_Vector},(Cint,N_Vector),count,w)
+end
+
+function N_VCloneVectorArrayEmpty_Serial(count::Int,w::N_Vector)
+    ccall((:N_VCloneVectorArrayEmpty_Serial,libsundials_nvecserial),Ptr{N_Vector},(Cint,N_Vector),count,w)
+end
+
+function N_VDestroyVectorArray_Serial(vs::Ptr{N_Vector},count::Int)
+    ccall((:N_VDestroyVectorArray_Serial,libsundials_nvecserial),Void,(Ptr{N_Vector},Cint),vs,count)
+end
+
+function N_VPrint_Serial(v::N_Vector)
+    ccall((:N_VPrint_Serial,libsundials_nvecserial),Void,(N_Vector,),v)
+end
+
+function N_VCloneEmpty_Serial(w::N_Vector)
+    ccall((:N_VCloneEmpty_Serial,libsundials_nvecserial),N_Vector,(N_Vector,),w)
+end
+
+function N_VClone_Serial(w::N_Vector)
+    ccall((:N_VClone_Serial,libsundials_nvecserial),N_Vector,(N_Vector,),w)
+end
+
+function N_VDestroy_Serial(v::N_Vector)
+    ccall((:N_VDestroy_Serial,libsundials_nvecserial),Void,(N_Vector,),v)
+end
+
+function N_VSpace_Serial(v::N_Vector,lrw::Ptr{Clong},liw::Ptr{Clong})
+    ccall((:N_VSpace_Serial,libsundials_nvecserial),Void,(N_Vector,Ptr{Clong},Ptr{Clong}),v,lrw,liw)
+end
+
+function N_VGetArrayPointer_Serial(v::N_Vector)
+    ccall((:N_VGetArrayPointer_Serial,libsundials_nvecserial),Ptr{realtype},(N_Vector,),v)
+end
+
+function N_VSetArrayPointer_Serial(v_data::Vector{realtype},v::N_Vector)
+    ccall((:N_VSetArrayPointer_Serial,libsundials_nvecserial),Void,(Ptr{realtype},N_Vector),v_data,v)
+end
+
+function N_VLinearSum_Serial(a::realtype,x::N_Vector,b::realtype,y::N_Vector,z::N_Vector)
+    ccall((:N_VLinearSum_Serial,libsundials_nvecserial),Void,(realtype,N_Vector,realtype,N_Vector,N_Vector),a,x,b,y,z)
+end
+
+function N_VConst_Serial(c::realtype,z::N_Vector)
+    ccall((:N_VConst_Serial,libsundials_nvecserial),Void,(realtype,N_Vector),c,z)
+end
+
+function N_VProd_Serial(x::N_Vector,y::N_Vector,z::N_Vector)
+    ccall((:N_VProd_Serial,libsundials_nvecserial),Void,(N_Vector,N_Vector,N_Vector),x,y,z)
+end
+
+function N_VDiv_Serial(x::N_Vector,y::N_Vector,z::N_Vector)
+    ccall((:N_VDiv_Serial,libsundials_nvecserial),Void,(N_Vector,N_Vector,N_Vector),x,y,z)
+end
+
+function N_VScale_Serial(c::realtype,x::N_Vector,z::N_Vector)
+    ccall((:N_VScale_Serial,libsundials_nvecserial),Void,(realtype,N_Vector,N_Vector),c,x,z)
+end
+
+function N_VAbs_Serial(x::N_Vector,z::N_Vector)
+    ccall((:N_VAbs_Serial,libsundials_nvecserial),Void,(N_Vector,N_Vector),x,z)
+end
+
+function N_VInv_Serial(x::N_Vector,z::N_Vector)
+    ccall((:N_VInv_Serial,libsundials_nvecserial),Void,(N_Vector,N_Vector),x,z)
+end
+
+function N_VAddConst_Serial(x::N_Vector,b::realtype,z::N_Vector)
+    ccall((:N_VAddConst_Serial,libsundials_nvecserial),Void,(N_Vector,realtype,N_Vector),x,b,z)
+end
+
+function N_VDotProd_Serial(x::N_Vector,y::N_Vector)
+    ccall((:N_VDotProd_Serial,libsundials_nvecserial),realtype,(N_Vector,N_Vector),x,y)
+end
+
+function N_VMaxNorm_Serial(x::N_Vector)
+    ccall((:N_VMaxNorm_Serial,libsundials_nvecserial),realtype,(N_Vector,),x)
+end
+
+function N_VWrmsNorm_Serial(x::N_Vector,w::N_Vector)
+    ccall((:N_VWrmsNorm_Serial,libsundials_nvecserial),realtype,(N_Vector,N_Vector),x,w)
+end
+
+function N_VWrmsNormMask_Serial(x::N_Vector,w::N_Vector,id::N_Vector)
+    ccall((:N_VWrmsNormMask_Serial,libsundials_nvecserial),realtype,(N_Vector,N_Vector,N_Vector),x,w,id)
+end
+
+function N_VMin_Serial(x::N_Vector)
+    ccall((:N_VMin_Serial,libsundials_nvecserial),realtype,(N_Vector,),x)
+end
+
+function N_VWL2Norm_Serial(x::N_Vector,w::N_Vector)
+    ccall((:N_VWL2Norm_Serial,libsundials_nvecserial),realtype,(N_Vector,N_Vector),x,w)
+end
+
+function N_VL1Norm_Serial(x::N_Vector)
+    ccall((:N_VL1Norm_Serial,libsundials_nvecserial),realtype,(N_Vector,),x)
+end
+
+function N_VCompare_Serial(c::realtype,x::N_Vector,z::N_Vector)
+    ccall((:N_VCompare_Serial,libsundials_nvecserial),Void,(realtype,N_Vector,N_Vector),c,x,z)
+end
+
+function N_VInvTest_Serial(x::N_Vector,z::N_Vector)
+    ccall((:N_VInvTest_Serial,libsundials_nvecserial),Cint,(N_Vector,N_Vector),x,z)
+end
+
+function N_VConstrMask_Serial(c::N_Vector,x::N_Vector,m::N_Vector)
+    ccall((:N_VConstrMask_Serial,libsundials_nvecserial),Cint,(N_Vector,N_Vector,N_Vector),c,x,m)
+end
+
+function N_VMinQuotient_Serial(num::N_Vector,denom::N_Vector)
+    ccall((:N_VMinQuotient_Serial,libsundials_nvecserial),realtype,(N_Vector,N_Vector),num,denom)
+end

--- a/src/sundials_h.jl
+++ b/src/sundials_h.jl
@@ -1,0 +1,2358 @@
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+
+using Compat
+
+const OBJC_NEW_PROPERTIES = 1
+const SUNDIALS_PACKAGE_VERSION = "2.5.0"
+const SUNDIALS_DOUBLE_PRECISION = 1
+const SUNDIALS_BLAS_LAPACK = 0
+# const FLT_EVAL_METHOD = __FLT_EVAL_METHOD__
+
+# Skipping MacroDefinition: FLT_ROUNDS ( __builtin_flt_rounds ( ) )
+
+# const FLT_RADIX = __FLT_RADIX__
+# const FLT_MANT_DIG = __FLT_MANT_DIG__
+# const DBL_MANT_DIG = __DBL_MANT_DIG__
+# const LDBL_MANT_DIG = __LDBL_MANT_DIG__
+# const DECIMAL_DIG = __DECIMAL_DIG__
+# const FLT_DIG = __FLT_DIG__
+# const DBL_DIG = __DBL_DIG__
+# const LDBL_DIG = __LDBL_DIG__
+# const FLT_MIN_EXP = __FLT_MIN_EXP__
+# const DBL_MIN_EXP = __DBL_MIN_EXP__
+# const LDBL_MIN_EXP = __LDBL_MIN_EXP__
+# const FLT_MIN_10_EXP = __FLT_MIN_10_EXP__
+# const DBL_MIN_10_EXP = __DBL_MIN_10_EXP__
+# const LDBL_MIN_10_EXP = __LDBL_MIN_10_EXP__
+# const FLT_MAX_EXP = __FLT_MAX_EXP__
+# const DBL_MAX_EXP = __DBL_MAX_EXP__
+# const LDBL_MAX_EXP = __LDBL_MAX_EXP__
+# const FLT_MAX_10_EXP = __FLT_MAX_10_EXP__
+# const DBL_MAX_10_EXP = __DBL_MAX_10_EXP__
+# const LDBL_MAX_10_EXP = __LDBL_MAX_10_EXP__
+# const FLT_MAX = __FLT_MAX__
+# const DBL_MAX = __DBL_MAX__
+# const LDBL_MAX = __LDBL_MAX__
+# const FLT_EPSILON = __FLT_EPSILON__
+# const DBL_EPSILON = __DBL_EPSILON__
+# const LDBL_EPSILON = __LDBL_EPSILON__
+# const FLT_MIN = __FLT_MIN__
+# const DBL_MIN = __DBL_MIN__
+# const LDBL_MIN = __LDBL_MIN__
+# const FLT_TRUE_MIN = __FLT_DENORM_MIN__
+# const DBL_TRUE_MIN = __DBL_DENORM_MIN__
+# const LDBL_TRUE_MIN = __LDBL_DENORM_MIN__
+
+# Skipping MacroDefinition: RCONST ( x ) x
+
+# const BIG_REAL = DBL_MAX
+# const SMALL_REAL = DBL_MIN
+# const UNIT_ROUNDOFF = DBL_EPSILON
+const FALSE = 0
+const TRUE = 1
+const SUNDIALS_DENSE = 1
+const SUNDIALS_BAND = 2
+
+# Skipping MacroDefinition: DENSE_COL ( A , j ) ( ( A -> cols ) [ j ] )
+# Skipping MacroDefinition: DENSE_ELEM ( A , i , j ) ( ( A -> cols ) [ j ] [ i ] )
+# Skipping MacroDefinition: BAND_COL ( A , j ) ( ( ( A -> cols ) [ j ] ) + ( A -> s_mu ) )
+# Skipping MacroDefinition: BAND_COL_ELEM ( col_j , i , j ) ( col_j [ ( i ) - ( j ) ] )
+# Skipping MacroDefinition: BAND_ELEM ( A , i , j ) ( ( A -> cols ) [ j ] [ ( i ) - ( j ) + ( A -> s_mu ) ] )
+
+typealias realtype Cdouble
+
+type _DlsMat
+    _type::Cint
+    M::Clong
+    N::Clong
+    ldim::Clong
+    mu::Clong
+    ml::Clong
+    s_mu::Clong
+    data::Ptr{realtype}
+    ldata::Clong
+    cols::Ptr{Ptr{realtype}}
+end
+
+typealias DlsMat Ptr{_DlsMat}
+
+type _generic_N_Vector_Ops
+    nvclone::Ptr{Void}
+    nvcloneempty::Ptr{Void}
+    nvdestroy::Ptr{Void}
+    nvspace::Ptr{Void}
+    nvgetarraypointer::Ptr{Void}
+    nvsetarraypointer::Ptr{Void}
+    nvlinearsum::Ptr{Void}
+    nvconst::Ptr{Void}
+    nvprod::Ptr{Void}
+    nvdiv::Ptr{Void}
+    nvscale::Ptr{Void}
+    nvabs::Ptr{Void}
+    nvinv::Ptr{Void}
+    nvaddconst::Ptr{Void}
+    nvdotprod::Ptr{Void}
+    nvmaxnorm::Ptr{Void}
+    nvwrmsnorm::Ptr{Void}
+    nvwrmsnormmask::Ptr{Void}
+    nvmin::Ptr{Void}
+    nvwl2norm::Ptr{Void}
+    nvl1norm::Ptr{Void}
+    nvcompare::Ptr{Void}
+    nvinvtest::Ptr{Void}
+    nvconstrmask::Ptr{Void}
+    nvminquotient::Ptr{Void}
+end
+
+typealias N_Vector_Ops Ptr{_generic_N_Vector_Ops}
+
+type _generic_N_Vector
+    content::Ptr{Void}
+    ops::Ptr{_generic_N_Vector_Ops}
+end
+
+typealias N_Vector Ptr{_generic_N_Vector}
+typealias N_Vector_S Ptr{N_Vector}
+
+# begin enum ANONYMOUS_1
+typealias ANONYMOUS_1 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_1
+
+# begin enum ANONYMOUS_47
+typealias ANONYMOUS_47 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_47
+
+# begin enum ANONYMOUS_2
+typealias ANONYMOUS_2 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_2
+
+# begin enum ANONYMOUS_48
+typealias ANONYMOUS_48 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_48
+
+typealias ATimesFn Ptr{Void}
+typealias PSolveFn Ptr{Void}
+
+const SPBCG_SUCCESS = 0
+const SPBCG_RES_REDUCED = 1
+const SPBCG_CONV_FAIL = 2
+const SPBCG_PSOLVE_FAIL_REC = 3
+const SPBCG_ATIMES_FAIL_REC = 4
+const SPBCG_PSET_FAIL_REC = 5
+const SPBCG_MEM_NULL = -1
+const SPBCG_ATIMES_FAIL_UNREC = -2
+const SPBCG_PSOLVE_FAIL_UNREC = -3
+const SPBCG_PSET_FAIL_UNREC = -4
+
+# Skipping MacroDefinition: SPBCG_VTEMP ( mem ) ( mem -> r )
+
+# begin enum ANONYMOUS_3
+typealias ANONYMOUS_3 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_3
+
+# begin enum ANONYMOUS_4
+typealias ANONYMOUS_4 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_4
+
+type SpbcgMemRec
+    l_max::Cint
+    r_star::N_Vector
+    r::N_Vector
+    p::N_Vector
+    q::N_Vector
+    u::N_Vector
+    Ap::N_Vector
+    vtemp::N_Vector
+end
+
+typealias SpbcgMem Ptr{Void}
+
+const SPGMR_SUCCESS = 0
+const SPGMR_RES_REDUCED = 1
+const SPGMR_CONV_FAIL = 2
+const SPGMR_QRFACT_FAIL = 3
+const SPGMR_PSOLVE_FAIL_REC = 4
+const SPGMR_ATIMES_FAIL_REC = 5
+const SPGMR_PSET_FAIL_REC = 6
+const SPGMR_MEM_NULL = -1
+const SPGMR_ATIMES_FAIL_UNREC = -2
+const SPGMR_PSOLVE_FAIL_UNREC = -3
+const SPGMR_GS_FAIL = -4
+const SPGMR_QRSOL_FAIL = -5
+const SPGMR_PSET_FAIL_UNREC = -6
+
+# Skipping MacroDefinition: SPGMR_VTEMP ( mem ) ( mem -> vtemp )
+
+# begin enum ANONYMOUS_5
+typealias ANONYMOUS_5 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_5
+
+# begin enum ANONYMOUS_6
+typealias ANONYMOUS_6 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_6
+
+type _SpgmrMemRec
+    l_max::Cint
+    V::Ptr{N_Vector}
+    Hes::Ptr{Ptr{realtype}}
+    givens::Ptr{realtype}
+    xcor::N_Vector
+    yg::Ptr{realtype}
+    vtemp::N_Vector
+end
+
+type SpgmrMemRec
+    l_max::Cint
+    V::Ptr{N_Vector}
+    Hes::Ptr{Ptr{realtype}}
+    givens::Ptr{realtype}
+    xcor::N_Vector
+    yg::Ptr{realtype}
+    vtemp::N_Vector
+end
+
+typealias SpgmrMem Ptr{_SpgmrMemRec}
+
+const SPTFQMR_SUCCESS = 0
+const SPTFQMR_RES_REDUCED = 1
+const SPTFQMR_CONV_FAIL = 2
+const SPTFQMR_PSOLVE_FAIL_REC = 3
+const SPTFQMR_ATIMES_FAIL_REC = 4
+const SPTFQMR_PSET_FAIL_REC = 5
+const SPTFQMR_MEM_NULL = -1
+const SPTFQMR_ATIMES_FAIL_UNREC = -2
+const SPTFQMR_PSOLVE_FAIL_UNREC = -3
+const SPTFQMR_PSET_FAIL_UNREC = -4
+
+# Skipping MacroDefinition: SPTFQMR_VTEMP ( mem ) ( mem -> vtemp1 )
+
+# begin enum ANONYMOUS_7
+typealias ANONYMOUS_7 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_7
+
+# begin enum ANONYMOUS_8
+typealias ANONYMOUS_8 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_8
+
+type SptfqmrMemRec
+    l_max::Cint
+    r_star::N_Vector
+    q::N_Vector
+    d::N_Vector
+    v::N_Vector
+    p::N_Vector
+    r::Ptr{N_Vector}
+    u::N_Vector
+    vtemp1::N_Vector
+    vtemp2::N_Vector
+    vtemp3::N_Vector
+end
+
+typealias SptfqmrMem Ptr{Void}
+
+# const NULL = __DARWIN_NULL
+const BUFSIZ = 1024
+const EOF = -1
+const FOPEN_MAX = 20
+const FILENAME_MAX = 1024
+const P_tmpdir = "/var/tmp/"
+const L_tmpnam = 1024
+const TMP_MAX = 308915776
+const SEEK_SET = 0
+const SEEK_CUR = 1
+const SEEK_END = 2
+# const stdin = __stdinp
+# const stdout = __stdoutp
+# const stderr = __stderrp
+const L_ctermid = 1024
+
+# Skipping MacroDefinition: getc_unlocked ( fp ) __sgetc ( fp )
+# Skipping MacroDefinition: putc_unlocked ( x , fp ) __sputc ( x , fp )
+# Skipping MacroDefinition: getchar_unlocked ( ) getc_unlocked ( stdin )
+# Skipping MacroDefinition: putchar_unlocked ( x ) putc_unlocked ( x , stdout )
+# Skipping MacroDefinition: fropen ( cookie , fn ) funopen ( cookie , fn , 0 , 0 , 0 )
+# Skipping MacroDefinition: fwopen ( cookie , fn ) funopen ( cookie , 0 , fn , 0 , 0 )
+# Skipping MacroDefinition: feof_unlocked ( p ) __sfeof ( p )
+# Skipping MacroDefinition: ferror_unlocked ( p ) __sferror ( p )
+# Skipping MacroDefinition: clearerr_unlocked ( p ) __sclearerr ( p )
+# Skipping MacroDefinition: fileno_unlocked ( p ) __sfileno ( p )
+# Skipping MacroDefinition: sprintf ( str , ... ) __builtin___sprintf_chk ( str , 0 , __darwin_obsz ( str ) , __VA_ARGS__ )
+# Skipping MacroDefinition: snprintf ( str , len , ... ) __builtin___snprintf_chk ( str , len , 0 , __darwin_obsz ( str ) , __VA_ARGS__ )
+# Skipping MacroDefinition: vsprintf ( str , format , ap ) __builtin___vsprintf_chk ( str , 0 , __darwin_obsz ( str ) , format , ap )
+# Skipping MacroDefinition: vsnprintf ( str , len , format , ap ) __builtin___vsnprintf_chk ( str , len , 0 , __darwin_obsz ( str ) , format , ap )
+
+const CV_ADAMS = 1
+const CV_BDF = 2
+const CV_FUNCTIONAL = 1
+const CV_NEWTON = 2
+const CV_NORMAL = 1
+const CV_ONE_STEP = 2
+const CV_SUCCESS = 0
+const CV_TSTOP_RETURN = 1
+const CV_ROOT_RETURN = 2
+const CV_WARNING = 99
+const CV_TOO_MUCH_WORK = -1
+const CV_TOO_MUCH_ACC = -2
+const CV_ERR_FAILURE = -3
+const CV_CONV_FAILURE = -4
+const CV_LINIT_FAIL = -5
+const CV_LSETUP_FAIL = -6
+const CV_LSOLVE_FAIL = -7
+const CV_RHSFUNC_FAIL = -8
+const CV_FIRST_RHSFUNC_ERR = -9
+const CV_REPTD_RHSFUNC_ERR = -10
+const CV_UNREC_RHSFUNC_ERR = -11
+const CV_RTFUNC_FAIL = -12
+const CV_MEM_FAIL = -20
+const CV_MEM_NULL = -21
+const CV_ILL_INPUT = -22
+const CV_NO_MALLOC = -23
+const CV_BAD_K = -24
+const CV_BAD_T = -25
+const CV_BAD_DKY = -26
+const CV_TOO_CLOSE = -27
+
+immutable Array_56_UInt8
+    d1::UInt8
+    d2::UInt8
+    d3::UInt8
+    d4::UInt8
+    d5::UInt8
+    d6::UInt8
+    d7::UInt8
+    d8::UInt8
+    d9::UInt8
+    d10::UInt8
+    d11::UInt8
+    d12::UInt8
+    d13::UInt8
+    d14::UInt8
+    d15::UInt8
+    d16::UInt8
+    d17::UInt8
+    d18::UInt8
+    d19::UInt8
+    d20::UInt8
+    d21::UInt8
+    d22::UInt8
+    d23::UInt8
+    d24::UInt8
+    d25::UInt8
+    d26::UInt8
+    d27::UInt8
+    d28::UInt8
+    d29::UInt8
+    d30::UInt8
+    d31::UInt8
+    d32::UInt8
+    d33::UInt8
+    d34::UInt8
+    d35::UInt8
+    d36::UInt8
+    d37::UInt8
+    d38::UInt8
+    d39::UInt8
+    d40::UInt8
+    d41::UInt8
+    d42::UInt8
+    d43::UInt8
+    d44::UInt8
+    d45::UInt8
+    d46::UInt8
+    d47::UInt8
+    d48::UInt8
+    d49::UInt8
+    d50::UInt8
+    d51::UInt8
+    d52::UInt8
+    d53::UInt8
+    d54::UInt8
+    d55::UInt8
+    d56::UInt8
+end
+
+zero(::Type{Array_56_UInt8}) = begin  # /Users/jgoldfar/.julia/v0.4/Clang/src/wrap_c.jl, line 266:
+        Array_56_UInt8(fill(zero(UInt8),56)...)
+    end
+
+type _opaque_pthread_attr_t
+    __sig::Clong
+    __opaque::Array_56_UInt8
+end
+
+immutable Array_40_UInt8
+    d1::UInt8
+    d2::UInt8
+    d3::UInt8
+    d4::UInt8
+    d5::UInt8
+    d6::UInt8
+    d7::UInt8
+    d8::UInt8
+    d9::UInt8
+    d10::UInt8
+    d11::UInt8
+    d12::UInt8
+    d13::UInt8
+    d14::UInt8
+    d15::UInt8
+    d16::UInt8
+    d17::UInt8
+    d18::UInt8
+    d19::UInt8
+    d20::UInt8
+    d21::UInt8
+    d22::UInt8
+    d23::UInt8
+    d24::UInt8
+    d25::UInt8
+    d26::UInt8
+    d27::UInt8
+    d28::UInt8
+    d29::UInt8
+    d30::UInt8
+    d31::UInt8
+    d32::UInt8
+    d33::UInt8
+    d34::UInt8
+    d35::UInt8
+    d36::UInt8
+    d37::UInt8
+    d38::UInt8
+    d39::UInt8
+    d40::UInt8
+end
+
+zero(::Type{Array_40_UInt8}) = begin  # /Users/jgoldfar/.julia/v0.4/Clang/src/wrap_c.jl, line 266:
+        Array_40_UInt8(fill(zero(UInt8),40)...)
+    end
+
+type _opaque_pthread_cond_t
+    __sig::Clong
+    __opaque::Array_40_UInt8
+end
+
+immutable Array_8_UInt8
+    d1::UInt8
+    d2::UInt8
+    d3::UInt8
+    d4::UInt8
+    d5::UInt8
+    d6::UInt8
+    d7::UInt8
+    d8::UInt8
+end
+
+zero(::Type{Array_8_UInt8}) = begin  # /Users/jgoldfar/.julia/v0.4/Clang/src/wrap_c.jl, line 266:
+        Array_8_UInt8(fill(zero(UInt8),8)...)
+    end
+
+type _opaque_pthread_condattr_t
+    __sig::Clong
+    __opaque::Array_8_UInt8
+end
+
+type _opaque_pthread_mutex_t
+    __sig::Clong
+    __opaque::Array_56_UInt8
+end
+
+type _opaque_pthread_mutexattr_t
+    __sig::Clong
+    __opaque::Array_8_UInt8
+end
+
+type _opaque_pthread_once_t
+    __sig::Clong
+    __opaque::Array_8_UInt8
+end
+
+immutable Array_192_UInt8
+    d1::UInt8
+    d2::UInt8
+    d3::UInt8
+    d4::UInt8
+    d5::UInt8
+    d6::UInt8
+    d7::UInt8
+    d8::UInt8
+    d9::UInt8
+    d10::UInt8
+    d11::UInt8
+    d12::UInt8
+    d13::UInt8
+    d14::UInt8
+    d15::UInt8
+    d16::UInt8
+    d17::UInt8
+    d18::UInt8
+    d19::UInt8
+    d20::UInt8
+    d21::UInt8
+    d22::UInt8
+    d23::UInt8
+    d24::UInt8
+    d25::UInt8
+    d26::UInt8
+    d27::UInt8
+    d28::UInt8
+    d29::UInt8
+    d30::UInt8
+    d31::UInt8
+    d32::UInt8
+    d33::UInt8
+    d34::UInt8
+    d35::UInt8
+    d36::UInt8
+    d37::UInt8
+    d38::UInt8
+    d39::UInt8
+    d40::UInt8
+    d41::UInt8
+    d42::UInt8
+    d43::UInt8
+    d44::UInt8
+    d45::UInt8
+    d46::UInt8
+    d47::UInt8
+    d48::UInt8
+    d49::UInt8
+    d50::UInt8
+    d51::UInt8
+    d52::UInt8
+    d53::UInt8
+    d54::UInt8
+    d55::UInt8
+    d56::UInt8
+    d57::UInt8
+    d58::UInt8
+    d59::UInt8
+    d60::UInt8
+    d61::UInt8
+    d62::UInt8
+    d63::UInt8
+    d64::UInt8
+    d65::UInt8
+    d66::UInt8
+    d67::UInt8
+    d68::UInt8
+    d69::UInt8
+    d70::UInt8
+    d71::UInt8
+    d72::UInt8
+    d73::UInt8
+    d74::UInt8
+    d75::UInt8
+    d76::UInt8
+    d77::UInt8
+    d78::UInt8
+    d79::UInt8
+    d80::UInt8
+    d81::UInt8
+    d82::UInt8
+    d83::UInt8
+    d84::UInt8
+    d85::UInt8
+    d86::UInt8
+    d87::UInt8
+    d88::UInt8
+    d89::UInt8
+    d90::UInt8
+    d91::UInt8
+    d92::UInt8
+    d93::UInt8
+    d94::UInt8
+    d95::UInt8
+    d96::UInt8
+    d97::UInt8
+    d98::UInt8
+    d99::UInt8
+    d100::UInt8
+    d101::UInt8
+    d102::UInt8
+    d103::UInt8
+    d104::UInt8
+    d105::UInt8
+    d106::UInt8
+    d107::UInt8
+    d108::UInt8
+    d109::UInt8
+    d110::UInt8
+    d111::UInt8
+    d112::UInt8
+    d113::UInt8
+    d114::UInt8
+    d115::UInt8
+    d116::UInt8
+    d117::UInt8
+    d118::UInt8
+    d119::UInt8
+    d120::UInt8
+    d121::UInt8
+    d122::UInt8
+    d123::UInt8
+    d124::UInt8
+    d125::UInt8
+    d126::UInt8
+    d127::UInt8
+    d128::UInt8
+    d129::UInt8
+    d130::UInt8
+    d131::UInt8
+    d132::UInt8
+    d133::UInt8
+    d134::UInt8
+    d135::UInt8
+    d136::UInt8
+    d137::UInt8
+    d138::UInt8
+    d139::UInt8
+    d140::UInt8
+    d141::UInt8
+    d142::UInt8
+    d143::UInt8
+    d144::UInt8
+    d145::UInt8
+    d146::UInt8
+    d147::UInt8
+    d148::UInt8
+    d149::UInt8
+    d150::UInt8
+    d151::UInt8
+    d152::UInt8
+    d153::UInt8
+    d154::UInt8
+    d155::UInt8
+    d156::UInt8
+    d157::UInt8
+    d158::UInt8
+    d159::UInt8
+    d160::UInt8
+    d161::UInt8
+    d162::UInt8
+    d163::UInt8
+    d164::UInt8
+    d165::UInt8
+    d166::UInt8
+    d167::UInt8
+    d168::UInt8
+    d169::UInt8
+    d170::UInt8
+    d171::UInt8
+    d172::UInt8
+    d173::UInt8
+    d174::UInt8
+    d175::UInt8
+    d176::UInt8
+    d177::UInt8
+    d178::UInt8
+    d179::UInt8
+    d180::UInt8
+    d181::UInt8
+    d182::UInt8
+    d183::UInt8
+    d184::UInt8
+    d185::UInt8
+    d186::UInt8
+    d187::UInt8
+    d188::UInt8
+    d189::UInt8
+    d190::UInt8
+    d191::UInt8
+    d192::UInt8
+end
+
+zero(::Type{Array_192_UInt8}) = begin  # /Users/jgoldfar/.julia/v0.4/Clang/src/wrap_c.jl, line 266:
+        Array_192_UInt8(fill(zero(UInt8),192)...)
+    end
+
+type _opaque_pthread_rwlock_t
+    __sig::Clong
+    __opaque::Array_192_UInt8
+end
+
+immutable Array_16_UInt8
+    d1::UInt8
+    d2::UInt8
+    d3::UInt8
+    d4::UInt8
+    d5::UInt8
+    d6::UInt8
+    d7::UInt8
+    d8::UInt8
+    d9::UInt8
+    d10::UInt8
+    d11::UInt8
+    d12::UInt8
+    d13::UInt8
+    d14::UInt8
+    d15::UInt8
+    d16::UInt8
+end
+
+zero(::Type{Array_16_UInt8}) = begin  # /Users/jgoldfar/.julia/v0.4/Clang/src/wrap_c.jl, line 266:
+        Array_16_UInt8(fill(zero(UInt8),16)...)
+    end
+
+immutable Array_3_Cuchar
+    d1::Cuchar
+    d2::Cuchar
+    d3::Cuchar
+end
+
+zero(::Type{Array_3_Cuchar}) = begin  # /Users/jgoldfar/.julia/v0.4/Clang/src/wrap_c.jl, line 266:
+        Array_3_Cuchar(fill(zero(Cuchar),3)...)
+    end
+
+immutable Array_1_Cuchar
+    d1::Cuchar
+end
+
+zero(::Type{Array_1_Cuchar}) = begin  # /Users/jgoldfar/.julia/v0.4/Clang/src/wrap_c.jl, line 266:
+        Array_1_Cuchar(fill(zero(Cuchar),1)...)
+    end
+
+# type FILE
+#     _p::Ptr{Cuchar}
+#     _r::Cint
+#     _w::Cint
+#     _flags::Int16
+#     _file::Int16
+#     _bf::__sbuf
+#     _lbfsize::Cint
+#     _cookie::Ptr{Void}
+#     _close::Ptr{Void}
+#     _read::Ptr{Void}
+#     _seek::Ptr{Void}
+#     _write::Ptr{Void}
+#     _ub::__sbuf
+#     _extra::Ptr{__sFILEX}
+#     _ur::Cint
+#     _ubuf::Array_3_Cuchar
+#     _nbuf::Array_1_Cuchar
+#     _lb::__sbuf
+#     _blksize::Cint
+#     _offset::fpos_t
+# end
+# 
+# typealias off_t __darwin_off_t
+# typealias ssize_t __darwin_ssize_t
+typealias CVRhsFn Ptr{Void}
+typealias CVRootFn Ptr{Void}
+typealias CVEwtFn Ptr{Void}
+typealias CVErrHandlerFn Ptr{Void}
+
+const CVDLS_SUCCESS = 0
+const CVDLS_MEM_NULL = -1
+const CVDLS_LMEM_NULL = -2
+const CVDLS_ILL_INPUT = -3
+const CVDLS_MEM_FAIL = -4
+const CVDLS_JACFUNC_UNRECVR = -5
+const CVDLS_JACFUNC_RECVR = -6
+
+typealias CVDlsDenseJacFn Ptr{Void}
+typealias CVDlsBandJacFn Ptr{Void}
+
+const CVSPILS_SUCCESS = 0
+const CVSPILS_MEM_NULL = -1
+const CVSPILS_LMEM_NULL = -2
+const CVSPILS_ILL_INPUT = -3
+const CVSPILS_MEM_FAIL = -4
+const CVSPILS_PMEM_NULL = -5
+const CVSPILS_MAXL = 5
+const CVSPILS_MSBPRE = 50
+
+# Skipping MacroDefinition: CVSPILS_DGMAX RCONST ( 0.2 )
+# Skipping MacroDefinition: CVSPILS_EPLIN RCONST ( 0.05 )
+
+# begin enum ANONYMOUS_9
+typealias ANONYMOUS_9 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_9
+
+# begin enum ANONYMOUS_10
+typealias ANONYMOUS_10 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_10
+
+typealias CVSpilsPrecSetupFn Ptr{Void}
+typealias CVSpilsPrecSolveFn Ptr{Void}
+typealias CVSpilsJacTimesVecFn Ptr{Void}
+
+const CV_SIMULTANEOUS = 1
+const CV_STAGGERED = 2
+const CV_STAGGERED1 = 3
+const CV_CENTERED = 1
+const CV_FORWARD = 2
+const CV_HERMITE = 1
+const CV_POLYNOMIAL = 2
+const CV_NO_QUAD = -30
+const CV_QRHSFUNC_FAIL = -31
+const CV_FIRST_QRHSFUNC_ERR = -32
+const CV_REPTD_QRHSFUNC_ERR = -33
+const CV_UNREC_QRHSFUNC_ERR = -34
+const CV_NO_SENS = -40
+const CV_SRHSFUNC_FAIL = -41
+const CV_FIRST_SRHSFUNC_ERR = -42
+const CV_REPTD_SRHSFUNC_ERR = -43
+const CV_UNREC_SRHSFUNC_ERR = -44
+const CV_BAD_IS = -45
+const CV_NO_QUADSENS = -50
+const CV_QSRHSFUNC_FAIL = -51
+const CV_FIRST_QSRHSFUNC_ERR = -52
+const CV_REPTD_QSRHSFUNC_ERR = -53
+const CV_UNREC_QSRHSFUNC_ERR = -54
+const CV_NO_ADJ = -101
+const CV_NO_FWD = -102
+const CV_NO_BCK = -103
+const CV_BAD_TB0 = -104
+const CV_REIFWD_FAIL = -105
+const CV_FWD_FAIL = -106
+const CV_GETY_BADT = -107
+
+typealias CVQuadRhsFn Ptr{Void}
+typealias CVSensRhsFn Ptr{Void}
+typealias CVSensRhs1Fn Ptr{Void}
+typealias CVQuadSensRhsFn Ptr{Void}
+typealias CVRhsFnB Ptr{Void}
+typealias CVRhsFnBS Ptr{Void}
+typealias CVQuadRhsFnB Ptr{Void}
+typealias CVQuadRhsFnBS Ptr{Void}
+
+type CVadjCheckPointRec
+    my_addr::Ptr{Void}
+    next_addr::Ptr{Void}
+    t0::realtype
+    t1::realtype
+    nstep::Clong
+    order::Cint
+    step::realtype
+end
+
+const CVDLS_NO_ADJ = -101
+const CVDLS_LMEMB_NULL = -102
+
+typealias CVDlsDenseJacFnB Ptr{Void}
+typealias CVDlsBandJacFnB Ptr{Void}
+
+const CVSPILS_NO_ADJ = -101
+const CVSPILS_LMEMB_NULL = -102
+
+# begin enum ANONYMOUS_11
+typealias ANONYMOUS_11 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_11
+
+# begin enum ANONYMOUS_12
+typealias ANONYMOUS_12 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_12
+
+typealias CVSpilsPrecSetupFnB Ptr{Void}
+typealias CVSpilsPrecSolveFnB Ptr{Void}
+typealias CVSpilsJacTimesVecFnB Ptr{Void}
+
+const IDA_NORMAL = 1
+const IDA_ONE_STEP = 2
+const IDA_YA_YDP_INIT = 1
+const IDA_Y_INIT = 2
+const IDA_SUCCESS = 0
+const IDA_TSTOP_RETURN = 1
+const IDA_ROOT_RETURN = 2
+const IDA_WARNING = 99
+const IDA_TOO_MUCH_WORK = -1
+const IDA_TOO_MUCH_ACC = -2
+const IDA_ERR_FAIL = -3
+const IDA_CONV_FAIL = -4
+const IDA_LINIT_FAIL = -5
+const IDA_LSETUP_FAIL = -6
+const IDA_LSOLVE_FAIL = -7
+const IDA_RES_FAIL = -8
+const IDA_REP_RES_ERR = -9
+const IDA_RTFUNC_FAIL = -10
+const IDA_CONSTR_FAIL = -11
+const IDA_FIRST_RES_FAIL = -12
+const IDA_LINESEARCH_FAIL = -13
+const IDA_NO_RECOVERY = -14
+const IDA_MEM_NULL = -20
+const IDA_MEM_FAIL = -21
+const IDA_ILL_INPUT = -22
+const IDA_NO_MALLOC = -23
+const IDA_BAD_EWT = -24
+const IDA_BAD_K = -25
+const IDA_BAD_T = -26
+const IDA_BAD_DKY = -27
+
+typealias IDAResFn Ptr{Void}
+typealias IDARootFn Ptr{Void}
+typealias IDAEwtFn Ptr{Void}
+typealias IDAErrHandlerFn Ptr{Void}
+
+const IDADLS_SUCCESS = 0
+const IDADLS_MEM_NULL = -1
+const IDADLS_LMEM_NULL = -2
+const IDADLS_ILL_INPUT = -3
+const IDADLS_MEM_FAIL = -4
+const IDADLS_JACFUNC_UNRECVR = -5
+const IDADLS_JACFUNC_RECVR = -6
+
+typealias IDADlsDenseJacFn Ptr{Void}
+typealias IDADlsBandJacFn Ptr{Void}
+
+const IDASPILS_SUCCESS = 0
+const IDASPILS_MEM_NULL = -1
+const IDASPILS_LMEM_NULL = -2
+const IDASPILS_ILL_INPUT = -3
+const IDASPILS_MEM_FAIL = -4
+const IDASPILS_PMEM_NULL = -5
+
+# begin enum ANONYMOUS_13
+typealias ANONYMOUS_13 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_13
+
+# begin enum ANONYMOUS_14
+typealias ANONYMOUS_14 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_14
+
+typealias IDASpilsPrecSetupFn Ptr{Void}
+typealias IDASpilsPrecSolveFn Ptr{Void}
+typealias IDASpilsJacTimesVecFn Ptr{Void}
+
+const IDA_SIMULTANEOUS = 1
+const IDA_STAGGERED = 2
+const IDA_CENTERED = 1
+const IDA_FORWARD = 2
+const IDA_HERMITE = 1
+const IDA_POLYNOMIAL = 2
+const IDA_NO_QUAD = -30
+const IDA_QRHS_FAIL = -31
+const IDA_FIRST_QRHS_ERR = -32
+const IDA_REP_QRHS_ERR = -33
+const IDA_NO_SENS = -40
+const IDA_SRES_FAIL = -41
+const IDA_REP_SRES_ERR = -42
+const IDA_BAD_IS = -43
+const IDA_NO_QUADSENS = -50
+const IDA_QSRHS_FAIL = -51
+const IDA_FIRST_QSRHS_ERR = -52
+const IDA_REP_QSRHS_ERR = -53
+const IDA_NO_ADJ = -101
+const IDA_NO_FWD = -102
+const IDA_NO_BCK = -103
+const IDA_BAD_TB0 = -104
+const IDA_REIFWD_FAIL = -105
+const IDA_FWD_FAIL = -106
+const IDA_GETY_BADT = -107
+
+typealias IDAQuadRhsFn Ptr{Void}
+typealias IDASensResFn Ptr{Void}
+typealias IDAQuadSensRhsFn Ptr{Void}
+typealias IDAResFnB Ptr{Void}
+typealias IDAResFnBS Ptr{Void}
+typealias IDAQuadRhsFnB Ptr{Void}
+typealias IDAQuadRhsFnBS Ptr{Void}
+
+type IDAadjCheckPointRec
+    my_addr::Ptr{Void}
+    next_addr::Ptr{Void}
+    t0::realtype
+    t1::realtype
+    nstep::Clong
+    order::Cint
+    step::realtype
+end
+
+const IDADLS_NO_ADJ = -101
+const IDADLS_LMEMB_NULL = -102
+
+typealias IDADlsDenseJacFnB Ptr{Void}
+typealias IDADlsBandJacFnB Ptr{Void}
+
+const IDASPILS_NO_ADJ = -101
+const IDASPILS_LMEMB_NULL = -102
+
+# begin enum ANONYMOUS_15
+typealias ANONYMOUS_15 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_15
+
+# begin enum ANONYMOUS_16
+typealias ANONYMOUS_16 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_16
+
+typealias IDASpilsPrecSetupFnB Ptr{Void}
+typealias IDASpilsPrecSolveFnB Ptr{Void}
+typealias IDASpilsJacTimesVecFnB Ptr{Void}
+
+const KIN_SUCCESS = 0
+const KIN_INITIAL_GUESS_OK = 1
+const KIN_STEP_LT_STPTOL = 2
+const KIN_WARNING = 99
+const KIN_MEM_NULL = -1
+const KIN_ILL_INPUT = -2
+const KIN_NO_MALLOC = -3
+const KIN_MEM_FAIL = -4
+const KIN_LINESEARCH_NONCONV = -5
+const KIN_MAXITER_REACHED = -6
+const KIN_MXNEWT_5X_EXCEEDED = -7
+const KIN_LINESEARCH_BCFAIL = -8
+const KIN_LINSOLV_NO_RECOVERY = -9
+const KIN_LINIT_FAIL = -10
+const KIN_LSETUP_FAIL = -11
+const KIN_LSOLVE_FAIL = -12
+const KIN_SYSFUNC_FAIL = -13
+const KIN_FIRST_SYSFUNC_ERR = -14
+const KIN_REPTD_SYSFUNC_ERR = -15
+const KIN_ETACHOICE1 = 1
+const KIN_ETACHOICE2 = 2
+const KIN_ETACONSTANT = 3
+const KIN_NONE = 0
+const KIN_LINESEARCH = 1
+
+typealias KINSysFn Ptr{Void}
+typealias KINErrHandlerFn Ptr{Void}
+typealias KINInfoHandlerFn Ptr{Void}
+
+const KINDLS_SUCCESS = 0
+const KINDLS_MEM_NULL = -1
+const KINDLS_LMEM_NULL = -2
+const KINDLS_ILL_INPUT = -3
+const KINDLS_MEM_FAIL = -4
+const KINDLS_JACFUNC_UNRECVR = -5
+const KINDLS_JACFUNC_RECVR = -6
+
+typealias KINDlsDenseJacFn Ptr{Void}
+typealias KINDlsBandJacFn Ptr{Void}
+
+const KINSPILS_SUCCESS = 0
+const KINSPILS_MEM_NULL = -1
+const KINSPILS_LMEM_NULL = -2
+const KINSPILS_ILL_INPUT = -3
+const KINSPILS_MEM_FAIL = -4
+const KINSPILS_PMEM_NULL = -5
+const KINSPILS_MAXL = 10
+
+# begin enum ANONYMOUS_17
+typealias ANONYMOUS_17 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_17
+
+# begin enum ANONYMOUS_18
+typealias ANONYMOUS_18 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_18
+
+typealias KINSpilsPrecSetupFn Ptr{Void}
+typealias KINSpilsPrecSolveFn Ptr{Void}
+typealias KINSpilsJacTimesVecFn Ptr{Void}
+
+# Skipping MacroDefinition: NV_CONTENT_S ( v ) ( ( N_VectorContent_Serial ) ( v -> content ) )
+# Skipping MacroDefinition: NV_LENGTH_S ( v ) ( NV_CONTENT_S ( v ) -> length )
+# Skipping MacroDefinition: NV_OWN_DATA_S ( v ) ( NV_CONTENT_S ( v ) -> own_data )
+# Skipping MacroDefinition: NV_DATA_S ( v ) ( NV_CONTENT_S ( v ) -> data )
+# Skipping MacroDefinition: NV_Ith_S ( v , i ) ( NV_DATA_S ( v ) [ i ] )
+
+type _N_VectorContent_Serial
+    length::Clong
+    own_data::Cint
+    data::Ptr{realtype}
+end
+
+typealias N_VectorContent_Serial Ptr{_N_VectorContent_Serial}
+
+const FCMIX_CVODE = 1
+const FCMIX_IDA = 2
+const FCMIX_KINSOL = 3
+
+# Skipping MacroDefinition: MIN ( A , B ) ( ( A ) < ( B ) ? ( A ) : ( B ) )
+# Skipping MacroDefinition: MAX ( A , B ) ( ( A ) > ( B ) ? ( A ) : ( B ) )
+# Skipping MacroDefinition: SQR ( A ) ( ( A ) * ( A ) )
+
+# const ABS = RAbs
+# const SQRT = RSqrt
+# const EXP = RExp
+
+typealias CVLocalFn Ptr{Void}
+typealias CVCommFn Ptr{Void}
+
+const CVDIAG_SUCCESS = 0
+const CVDIAG_MEM_NULL = -1
+const CVDIAG_LMEM_NULL = -2
+const CVDIAG_ILL_INPUT = -3
+const CVDIAG_MEM_FAIL = -4
+const CVDIAG_INV_FAIL = -5
+const CVDIAG_RHSFUNC_UNRECVR = -6
+const CVDIAG_RHSFUNC_RECVR = -7
+
+# Skipping MacroDefinition: va_start ( ap , param ) __builtin_va_start ( ap , param )
+# Skipping MacroDefinition: va_end ( ap ) __builtin_va_end ( ap )
+# Skipping MacroDefinition: va_arg ( ap , type ) __builtin_va_arg ( ap , type )
+# Skipping MacroDefinition: va_copy ( dest , src ) __builtin_va_copy ( dest , src )
+
+const ADAMS_Q_MAX = 12
+const BDF_Q_MAX = 5
+const Q_MAX = ADAMS_Q_MAX
+const L_MAX = Q_MAX + 1
+const NUM_TESTS = 5
+
+# Skipping MacroDefinition: HMIN_DEFAULT RCONST ( 0.0 )
+# Skipping MacroDefinition: HMAX_INV_DEFAULT RCONST ( 0.0 )
+
+const MXHNIL_DEFAULT = 10
+const MXSTEP_DEFAULT = 500
+const CV_NO_FAILURES = 0
+const CV_FAIL_BAD_J = 1
+const CV_FAIL_OTHER = 2
+const MSG_TIME = "t = %lg, "
+const MSG_TIME_H = "t = %lg and h = %lg, "
+const MSG_TIME_INT = "t = %lg is not between tcur - hu = %lg and tcur = %lg."
+const MSG_TIME_TOUT = "tout = %lg"
+const MSG_TIME_TSTOP = "tstop = %lg"
+const MSGCV_NO_MEM = "cvode_mem = NULL illegal."
+const MSGCV_CVMEM_FAIL = "Allocation of cvode_mem failed."
+const MSGCV_MEM_FAIL = "A memory request failed."
+const MSGCV_BAD_LMM = "Illegal value for lmm. The legal values are CV_ADAMS and CV_BDF."
+const MSGCV_BAD_ITER = "Illegal value for iter. The legal values are CV_FUNCTIONAL and CV_NEWTON."
+const MSGCV_NO_MALLOC = "Attempt to call before CVodeInit."
+const MSGCV_NEG_MAXORD = "maxord <= 0 illegal."
+const MSGCV_BAD_MAXORD = "Illegal attempt to increase maximum method order."
+const MSGCV_SET_SLDET = "Attempt to use stability limit detection with the CV_ADAMS method illegal."
+const MSGCV_NEG_HMIN = "hmin < 0 illegal."
+const MSGCV_NEG_HMAX = "hmax < 0 illegal."
+const MSGCV_BAD_HMIN_HMAX = "Inconsistent step size limits: hmin > hmax."
+const MSGCV_BAD_RELTOL = "reltol < 0 illegal."
+const MSGCV_BAD_ABSTOL = "abstol has negative component(s) (illegal)."
+const MSGCV_NULL_ABSTOL = "abstol = NULL illegal."
+const MSGCV_NULL_Y0 = "y0 = NULL illegal."
+const MSGCV_NULL_F = "f = NULL illegal."
+const MSGCV_NULL_G = "g = NULL illegal."
+const MSGCV_BAD_NVECTOR = "A required vector operation is not implemented."
+const MSGCV_BAD_K = "Illegal value for k."
+const MSGCV_NULL_DKY = "dky = NULL illegal."
+const MSGCV_BAD_T = "Illegal value for t."
+const MSGCV_NO_ROOT = "Rootfinding was not initialized."
+const MSGCV_NO_TOLS = "No integration tolerances for sensitivity variables have been specified."
+const MSGCV_LSOLVE_NULL = "The linear solver's solve routine is NULL."
+const MSGCV_YOUT_NULL = "yout = NULL illegal."
+const MSGCV_TRET_NULL = "tret = NULL illegal."
+const MSGCV_BAD_EWT = "Initial ewt has component(s) equal to zero (illegal)."
+
+# Skipping MacroDefinition: MSGCV_EWT_NOW_BAD "At " MSG_TIME ", a component of ewt has become <= 0."
+
+const MSGCV_BAD_ITASK = "Illegal value for itask."
+const MSGCV_BAD_H0 = "h0 and tout - t0 inconsistent."
+
+# Skipping MacroDefinition: MSGCV_BAD_TOUT "Trouble interpolating at " MSG_TIME_TOUT ". tout too far back in direction of integration"
+
+const MSGCV_EWT_FAIL = "The user-provide EwtSet function failed."
+
+# Skipping MacroDefinition: MSGCV_EWT_NOW_FAIL "At " MSG_TIME ", the user-provide EwtSet function failed."
+
+const MSGCV_LINIT_FAIL = "The linear solver's init routine failed."
+const MSGCV_HNIL_DONE = "The above warning has been issued mxhnil times and will not be issued again for this problem."
+const MSGCV_TOO_CLOSE = "tout too close to t0 to start integration."
+
+# Skipping MacroDefinition: MSGCV_MAX_STEPS "At " MSG_TIME ", mxstep steps taken before reaching tout."
+# Skipping MacroDefinition: MSGCV_TOO_MUCH_ACC "At " MSG_TIME ", too much accuracy requested."
+# Skipping MacroDefinition: MSGCV_HNIL "Internal " MSG_TIME_H " are such that t + h = t on the next step. The solver will continue anyway."
+# Skipping MacroDefinition: MSGCV_ERR_FAILS "At " MSG_TIME_H ", the error test failed repeatedly or with |h| = hmin."
+# Skipping MacroDefinition: MSGCV_CONV_FAILS "At " MSG_TIME_H ", the corrector convergence test failed repeatedly or with |h| = hmin."
+# Skipping MacroDefinition: MSGCV_SETUP_FAILED "At " MSG_TIME ", the setup routine failed in an unrecoverable manner."
+# Skipping MacroDefinition: MSGCV_SOLVE_FAILED "At " MSG_TIME ", the solve routine failed in an unrecoverable manner."
+# Skipping MacroDefinition: MSGCV_RHSFUNC_FAILED "At " MSG_TIME ", the right-hand side routine failed in an unrecoverable manner."
+# Skipping MacroDefinition: MSGCV_RHSFUNC_UNREC "At " MSG_TIME ", the right-hand side failed in a recoverable manner, but no recovery is possible."
+# Skipping MacroDefinition: MSGCV_RHSFUNC_REPTD "At " MSG_TIME " repeated recoverable right-hand side function errors."
+
+const MSGCV_RHSFUNC_FIRST = "The right-hand side routine failed at the first call."
+
+# Skipping MacroDefinition: MSGCV_RTFUNC_FAILED "At " MSG_TIME ", the rootfinding routine failed in an unrecoverable manner."
+# Skipping MacroDefinition: MSGCV_CLOSE_ROOTS "Root found at and very near " MSG_TIME "."
+# Skipping MacroDefinition: MSGCV_BAD_TSTOP "The value " MSG_TIME_TSTOP " is behind current " MSG_TIME " in the direction of integration."
+
+const MSGCV_INACTIVE_ROOTS = "At the end of the first step, there are still some root functions identically 0. This warning will not be issued again."
+
+immutable Array_13_N_Vector
+    d1::N_Vector
+    d2::N_Vector
+    d3::N_Vector
+    d4::N_Vector
+    d5::N_Vector
+    d6::N_Vector
+    d7::N_Vector
+    d8::N_Vector
+    d9::N_Vector
+    d10::N_Vector
+    d11::N_Vector
+    d12::N_Vector
+    d13::N_Vector
+end
+
+zero(::Type{Array_13_N_Vector}) = begin  # /Users/jgoldfar/.julia/v0.4/Clang/src/wrap_c.jl, line 266:
+        Array_13_N_Vector(fill(zero(N_Vector),13)...)
+    end
+
+immutable Array_14_realtype
+    d1::realtype
+    d2::realtype
+    d3::realtype
+    d4::realtype
+    d5::realtype
+    d6::realtype
+    d7::realtype
+    d8::realtype
+    d9::realtype
+    d10::realtype
+    d11::realtype
+    d12::realtype
+    d13::realtype
+    d14::realtype
+end
+
+zero(::Type{Array_14_realtype}) = begin  # /Users/jgoldfar/.julia/v0.4/Clang/src/wrap_c.jl, line 266:
+        Array_14_realtype(fill(zero(realtype),14)...)
+    end
+
+immutable Array_6_realtype
+    d1::realtype
+    d2::realtype
+    d3::realtype
+    d4::realtype
+    d5::realtype
+    d6::realtype
+end
+
+zero(::Type{Array_6_realtype}) = begin  # /Users/jgoldfar/.julia/v0.4/Clang/src/wrap_c.jl, line 266:
+        Array_6_realtype(fill(zero(realtype),6)...)
+    end
+
+immutable Array_13_realtype
+    d1::realtype
+    d2::realtype
+    d3::realtype
+    d4::realtype
+    d5::realtype
+    d6::realtype
+    d7::realtype
+    d8::realtype
+    d9::realtype
+    d10::realtype
+    d11::realtype
+    d12::realtype
+    d13::realtype
+end
+
+zero(::Type{Array_13_realtype}) = begin  # /Users/jgoldfar/.julia/v0.4/Clang/src/wrap_c.jl, line 266:
+        Array_13_realtype(fill(zero(realtype),13)...)
+    end
+
+immutable Array_4_realtype
+    d1::realtype
+    d2::realtype
+    d3::realtype
+    d4::realtype
+end
+
+zero(::Type{Array_4_realtype}) = begin  # /Users/jgoldfar/.julia/v0.4/Clang/src/wrap_c.jl, line 266:
+        Array_4_realtype(fill(zero(realtype),4)...)
+    end
+
+immutable Array_6_Array_4_realtype
+    d1::Array_4_realtype
+    d2::Array_4_realtype
+    d3::Array_4_realtype
+    d4::Array_4_realtype
+    d5::Array_4_realtype
+    d6::Array_4_realtype
+end
+
+zero(::Type{Array_6_Array_4_realtype}) = begin  # /Users/jgoldfar/.julia/v0.4/Clang/src/wrap_c.jl, line 266:
+        Array_6_Array_4_realtype(fill(zero(Array_4_realtype),6)...)
+    end
+
+type CVodeMemRec
+    cv_uround::realtype
+    cv_f::CVRhsFn
+    cv_user_data::Ptr{Void}
+    cv_lmm::Cint
+    cv_iter::Cint
+    cv_itol::Cint
+    cv_reltol::realtype
+    cv_Sabstol::realtype
+    cv_Vabstol::N_Vector
+    cv_user_efun::Cint
+    cv_efun::CVEwtFn
+    cv_e_data::Ptr{Void}
+    cv_zn::Array_13_N_Vector
+    cv_ewt::N_Vector
+    cv_y::N_Vector
+    cv_acor::N_Vector
+    cv_tempv::N_Vector
+    cv_ftemp::N_Vector
+    cv_tstopset::Cint
+    cv_tstop::realtype
+    cv_q::Cint
+    cv_qprime::Cint
+    cv_next_q::Cint
+    cv_qwait::Cint
+    cv_L::Cint
+    cv_hin::realtype
+    cv_h::realtype
+    cv_hprime::realtype
+    cv_next_h::realtype
+    cv_eta::realtype
+    cv_hscale::realtype
+    cv_tn::realtype
+    cv_tretlast::realtype
+    cv_tau::Array_14_realtype
+    cv_tq::Array_6_realtype
+    cv_l::Array_13_realtype
+    cv_rl1::realtype
+    cv_gamma::realtype
+    cv_gammap::realtype
+    cv_gamrat::realtype
+    cv_crate::realtype
+    cv_acnrm::realtype
+    cv_nlscoef::realtype
+    cv_mnewt::Cint
+    cv_qmax::Cint
+    cv_mxstep::Clong
+    cv_maxcor::Cint
+    cv_mxhnil::Cint
+    cv_maxnef::Cint
+    cv_maxncf::Cint
+    cv_hmin::realtype
+    cv_hmax_inv::realtype
+    cv_etamax::realtype
+    cv_nst::Clong
+    cv_nfe::Clong
+    cv_ncfn::Clong
+    cv_netf::Clong
+    cv_nni::Clong
+    cv_nsetups::Clong
+    cv_nhnil::Cint
+    cv_etaqm1::realtype
+    cv_etaq::realtype
+    cv_etaqp1::realtype
+    cv_lrw1::Clong
+    cv_liw1::Clong
+    cv_lrw::Clong
+    cv_liw::Clong
+    cv_linit::Ptr{Void}
+    cv_lsetup::Ptr{Void}
+    cv_lsolve::Ptr{Void}
+    cv_lfree::Ptr{Void}
+    cv_lmem::Ptr{Void}
+    cv_qu::Cint
+    cv_nstlp::Clong
+    cv_h0u::realtype
+    cv_hu::realtype
+    cv_saved_tq5::realtype
+    cv_jcur::Cint
+    cv_tolsf::realtype
+    cv_qmax_alloc::Cint
+    cv_indx_acor::Cint
+    cv_setupNonNull::Cint
+    cv_VabstolMallocDone::Cint
+    cv_MallocDone::Cint
+    cv_ehfun::CVErrHandlerFn
+    cv_eh_data::Ptr{Void}
+    # cv_errfp::Ptr{Void}
+    cv_errfp::Ptr{Void}
+    cv_sldeton::Cint
+    cv_ssdat::Array_6_Array_4_realtype
+    cv_nscon::Cint
+    cv_nor::Clong
+    cv_gfun::CVRootFn
+    cv_nrtfn::Cint
+    cv_iroots::Ptr{Cint}
+    cv_rootdir::Ptr{Cint}
+    cv_tlo::realtype
+    cv_thi::realtype
+    cv_trout::realtype
+    cv_glo::Ptr{realtype}
+    cv_ghi::Ptr{realtype}
+    cv_grout::Ptr{realtype}
+    cv_toutc::realtype
+    cv_ttol::realtype
+    cv_taskc::Cint
+    cv_irfnd::Cint
+    cv_nge::Clong
+    cv_gactive::Ptr{Cint}
+    cv_mxgnull::Cint
+end
+
+typealias CVodeMem Ptr{CVodeMemRec}
+
+# begin enum ANONYMOUS_19
+typealias ANONYMOUS_19 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_19
+
+# begin enum ANONYMOUS_20
+typealias ANONYMOUS_20 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_20
+
+# begin enum ANONYMOUS_21
+typealias ANONYMOUS_21 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_21
+
+# begin enum ANONYMOUS_22
+typealias ANONYMOUS_22 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_22
+
+# begin enum ANONYMOUS_23
+typealias ANONYMOUS_23 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_23
+
+# begin enum ANONYMOUS_24
+typealias ANONYMOUS_24 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_24
+
+typealias CVLocalFnB Ptr{Void}
+typealias CVCommFnB Ptr{Void}
+
+const CVDIAG_NO_ADJ = -101
+const MSGCV_NO_QUAD = "Quadrature integration not activated."
+const MSGCV_BAD_ITOLQ = "Illegal value for itolQ. The legal values are CV_SS and CV_SV."
+const MSGCV_NULL_ABSTOLQ = "abstolQ = NULL illegal."
+const MSGCV_BAD_RELTOLQ = "reltolQ < 0 illegal."
+const MSGCV_BAD_ABSTOLQ = "abstolQ has negative component(s) (illegal)."
+const MSGCV_SENSINIT_2 = "Sensitivity analysis already initialized."
+const MSGCV_NO_SENSI = "Forward sensitivity analysis not activated."
+const MSGCV_BAD_ITOLS = "Illegal value for itolS. The legal values are CV_SS, CV_SV, and CV_EE."
+const MSGCV_NULL_ABSTOLS = "abstolS = NULL illegal."
+const MSGCV_BAD_RELTOLS = "reltolS < 0 illegal."
+const MSGCV_BAD_ABSTOLS = "abstolS has negative component(s) (illegal)."
+const MSGCV_BAD_PBAR = "pbar has zero component(s) (illegal)."
+const MSGCV_BAD_PLIST = "plist has negative component(s) (illegal)."
+const MSGCV_BAD_NS = "NS <= 0 illegal."
+const MSGCV_NULL_YS0 = "yS0 = NULL illegal."
+const MSGCV_BAD_ISM = "Illegal value for ism. Legal values are: CV_SIMULTANEOUS, CV_STAGGERED and CV_STAGGERED1."
+const MSGCV_BAD_IFS = "Illegal value for ifS. Legal values are: CV_ALLSENS and CV_ONESENS."
+const MSGCV_BAD_ISM_IFS = "Illegal ism = CV_STAGGERED1 for CVodeSensInit."
+const MSGCV_BAD_IS = "Illegal value for is."
+const MSGCV_NULL_DKYA = "dkyA = NULL illegal."
+const MSGCV_BAD_DQTYPE = "Illegal value for DQtype. Legal values are: CV_CENTERED and CV_FORWARD."
+const MSGCV_BAD_DQRHO = "DQrhomax < 0 illegal."
+const MSGCV_BAD_ITOLQS = "Illegal value for itolQS. The legal values are CV_SS, CV_SV, and CV_EE."
+const MSGCV_NULL_ABSTOLQS = "abstolQS = NULL illegal."
+const MSGCV_BAD_RELTOLQS = "reltolQS < 0 illegal."
+const MSGCV_BAD_ABSTOLQS = "abstolQS has negative component(s) (illegal)."
+const MSGCV_NO_QUADSENSI = "Forward sensitivity analysis for quadrature variables not activated."
+const MSGCV_NULL_YQS0 = "yQS0 = NULL illegal."
+const MSGCV_NO_TOL = "No integration tolerances have been specified."
+const MSGCV_NO_TOLQ = "No integration tolerances for quadrature variables have been specified."
+const MSGCV_BAD_EWTQ = "Initial ewtQ has component(s) equal to zero (illegal)."
+
+# Skipping MacroDefinition: MSGCV_EWTQ_NOW_BAD "At " MSG_TIME ", a component of ewtQ has become <= 0."
+# Skipping MacroDefinition: MSGCV_QRHSFUNC_FAILED "At " MSG_TIME ", the quadrature right-hand side routine failed in an unrecoverable manner."
+# Skipping MacroDefinition: MSGCV_QRHSFUNC_UNREC "At " MSG_TIME ", the quadrature right-hand side failed in a recoverable manner, but no recovery is possible."
+# Skipping MacroDefinition: MSGCV_QRHSFUNC_REPTD "At " MSG_TIME " repeated recoverable quadrature right-hand side function errors."
+
+const MSGCV_QRHSFUNC_FIRST = "The quadrature right-hand side routine failed at the first call."
+const MSGCV_NULL_P = "p = NULL when using internal DQ for sensitivity RHS illegal."
+const MSGCV_BAD_EWTS = "Initial ewtS has component(s) equal to zero (illegal)."
+
+# Skipping MacroDefinition: MSGCV_EWTS_NOW_BAD "At " MSG_TIME ", a component of ewtS has become <= 0."
+# Skipping MacroDefinition: MSGCV_SRHSFUNC_FAILED "At " MSG_TIME ", the sensitivity right-hand side routine failed in an unrecoverable manner."
+# Skipping MacroDefinition: MSGCV_SRHSFUNC_UNREC "At " MSG_TIME ", the sensitivity right-hand side failed in a recoverable manner, but no recovery is possible."
+# Skipping MacroDefinition: MSGCV_SRHSFUNC_REPTD "At " MSG_TIME " repeated recoverable sensitivity right-hand side function errors."
+
+const MSGCV_SRHSFUNC_FIRST = "The sensitivity right-hand side routine failed at the first call."
+const MSGCV_NULL_FQ = "CVODES is expected to use DQ to evaluate the RHS of quad. sensi., but quadratures were not initialized."
+const MSGCV_NO_TOLQS = "No integration tolerances for quadrature sensitivity variables have been specified."
+const MSGCV_BAD_EWTQS = "Initial ewtQS has component(s) equal to zero (illegal)."
+
+# Skipping MacroDefinition: MSGCV_EWTQS_NOW_BAD "At " MSG_TIME ", a component of ewtQS has become <= 0."
+# Skipping MacroDefinition: MSGCV_QSRHSFUNC_FAILED "At " MSG_TIME ", the quadrature sensitivity right-hand side routine failed in an unrecoverable manner."
+# Skipping MacroDefinition: MSGCV_QSRHSFUNC_UNREC "At " MSG_TIME ", the quadrature sensitivity right-hand side failed in a recoverable manner, but no recovery is possible."
+# Skipping MacroDefinition: MSGCV_QSRHSFUNC_REPTD "At " MSG_TIME " repeated recoverable quadrature sensitivity right-hand side function errors."
+
+const MSGCV_QSRHSFUNC_FIRST = "The quadrature sensitivity right-hand side routine failed at the first call."
+const MSGCV_NO_ADJ = "Illegal attempt to call before calling CVodeAdjMalloc."
+const MSGCV_BAD_STEPS = "Steps nonpositive illegal."
+const MSGCV_BAD_INTERP = "Illegal value for interp."
+const MSGCV_BAD_WHICH = "Illegal value for which."
+const MSGCV_NO_BCK = "No backward problems have been defined yet."
+const MSGCV_NO_FWD = "Illegal attempt to call before calling CVodeF."
+const MSGCV_BAD_TB0 = "The initial time tB0 for problem %d is outside the interval over which the forward problem was solved."
+const MSGCV_BAD_SENSI = "At least one backward problem requires sensitivities, but they were not stored for interpolation."
+const MSGCV_BAD_ITASKB = "Illegal value for itaskB. Legal values are CV_NORMAL and CV_ONE_STEP."
+const MSGCV_BAD_TBOUT = "The final time tBout is outside the interval over which the forward problem was solved."
+const MSGCV_BACK_ERROR = "Error occured while integrating backward problem # %d"
+const MSGCV_BAD_TINTERP = "Bad t = %g for interpolation."
+const MSGCV_WRONG_INTERP = "This function cannot be called for the specified interp type."
+
+type CVodeBMemRec
+    cv_index::Cint
+    cv_t0::realtype
+    cv_mem::CVodeMem
+    cv_f_withSensi::Cint
+    cv_fQ_withSensi::Cint
+    cv_f::CVRhsFnB
+    cv_fs::CVRhsFnBS
+    cv_fQ::CVQuadRhsFnB
+    cv_fQs::CVQuadRhsFnBS
+    cv_user_data::Ptr{Void}
+    cv_lmem::Ptr{Void}
+    cv_lfree::Ptr{Void}
+    cv_pmem::Ptr{Void}
+    cv_pfree::Ptr{Void}
+    cv_tout::realtype
+    cv_y::N_Vector
+    cv_next::Ptr{CVodeBMemRec}
+end
+
+immutable Array_13_Ptr
+    d1::Ptr{N_Vector}
+    d2::Ptr{N_Vector}
+    d3::Ptr{N_Vector}
+    d4::Ptr{N_Vector}
+    d5::Ptr{N_Vector}
+    d6::Ptr{N_Vector}
+    d7::Ptr{N_Vector}
+    d8::Ptr{N_Vector}
+    d9::Ptr{N_Vector}
+    d10::Ptr{N_Vector}
+    d11::Ptr{N_Vector}
+    d12::Ptr{N_Vector}
+    d13::Ptr{N_Vector}
+end
+
+zero(::Type{Array_13_Ptr}) = begin  # /Users/jgoldfar/.julia/v0.4/Clang/src/wrap_c.jl, line 266:
+        Array_13_Ptr(fill(zero(Ptr{N_Vector}),13)...)
+    end
+
+type CkpntMemRec
+    ck_t0::realtype
+    ck_t1::realtype
+    ck_zn::Array_13_N_Vector
+    ck_quadr::Cint
+    ck_znQ::Array_13_N_Vector
+    ck_sensi::Cint
+    ck_Ns::Cint
+    ck_znS::Array_13_Ptr
+    ck_quadr_sensi::Cint
+    ck_znQS::Array_13_Ptr
+    ck_zqm::Cint
+    ck_nst::Clong
+    ck_tretlast::realtype
+    ck_q::Cint
+    ck_qprime::Cint
+    ck_qwait::Cint
+    ck_L::Cint
+    ck_gammap::realtype
+    ck_h::realtype
+    ck_hprime::realtype
+    ck_hscale::realtype
+    ck_eta::realtype
+    ck_etamax::realtype
+    ck_tau::Array_14_realtype
+    ck_tq::Array_6_realtype
+    ck_l::Array_13_realtype
+    ck_saved_tq5::realtype
+    ck_next::Ptr{CkpntMemRec}
+end
+
+type DtpntMemRec
+    t::realtype
+    content::Ptr{Void}
+end
+
+typealias cvaIMMallocFn Ptr{Void}
+typealias cvaIMFreeFn Ptr{Void}
+typealias cvaIMStorePntFn Ptr{Void}
+typealias cvaIMGetYFn Ptr{Void}
+
+type CVadjMemRec
+    ca_tinitial::realtype
+    ca_tfinal::realtype
+    ca_firstCVodeFcall::Cint
+    ca_tstopCVodeFcall::Cint
+    ca_tstopCVodeF::realtype
+    cvB_mem::Ptr{CVodeBMemRec}
+    ca_nbckpbs::Cint
+    ca_bckpbCrt::Ptr{CVodeBMemRec}
+    ca_firstCVodeBcall::Cint
+    ck_mem::Ptr{CkpntMemRec}
+    ca_nckpnts::Cint
+    ca_ckpntData::Ptr{CkpntMemRec}
+    ca_nsteps::Clong
+    dt_mem::Ptr{Ptr{DtpntMemRec}}
+    ca_np::Clong
+    ca_IMtype::Cint
+    ca_IMmalloc::cvaIMMallocFn
+    ca_IMfree::cvaIMFreeFn
+    ca_IMstore::cvaIMStorePntFn
+    ca_IMget::cvaIMGetYFn
+    ca_IMmallocDone::Cint
+    ca_IMnewData::Cint
+    ca_IMstoreSensi::Cint
+    ca_IMinterpSensi::Cint
+    ca_Y::Array_13_N_Vector
+    ca_YS::Array_13_Ptr
+    ca_T::Array_13_realtype
+    ca_ytmp::N_Vector
+    ca_yStmp::Ptr{N_Vector}
+end
+
+typealias CVadjMem Ptr{CVadjMemRec}
+typealias CkpntMem Ptr{CkpntMemRec}
+typealias DtpntMem Ptr{DtpntMemRec}
+typealias CVodeBMem Ptr{CVodeBMemRec}
+
+type HermiteDataMemRec
+    y::N_Vector
+    yd::N_Vector
+    yS::Ptr{N_Vector}
+    ySd::Ptr{N_Vector}
+end
+
+typealias HermiteDataMem Ptr{HermiteDataMemRec}
+
+type PolynomialDataMemRec
+    y::N_Vector
+    yS::Ptr{N_Vector}
+    order::Cint
+end
+
+typealias PolynomialDataMem Ptr{PolynomialDataMemRec}
+
+# begin enum ANONYMOUS_25
+typealias ANONYMOUS_25 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_25
+
+# begin enum ANONYMOUS_26
+typealias ANONYMOUS_26 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_26
+
+# begin enum ANONYMOUS_27
+typealias ANONYMOUS_27 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_27
+
+# begin enum ANONYMOUS_28
+typealias ANONYMOUS_28 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_28
+
+# begin enum ANONYMOUS_29
+typealias ANONYMOUS_29 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_29
+
+# begin enum ANONYMOUS_30
+typealias ANONYMOUS_30 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_30
+
+typealias IDABBDLocalFn Ptr{Void}
+typealias IDABBDCommFn Ptr{Void}
+
+const MAXORD_DEFAULT = 5
+const MXORDP1 = 6
+const MSG_MEM_FAIL = "A memory request failed."
+const MSG_NO_MEM = "kinsol_mem = NULL illegal."
+const MSG_NO_MALLOC = "Attempt to call before KINMalloc illegal."
+const MSG_BAD_NVECTOR = "A required vector operation is not implemented."
+const MSG_Y0_NULL = "y0 = NULL illegal."
+const MSG_YP0_NULL = "yp0 = NULL illegal."
+const MSG_BAD_ITOL = "Illegal value for itol. The legal values are IDA_SS, IDA_SV, and IDA_WF."
+const MSG_RES_NULL = "res = NULL illegal."
+const MSG_BAD_RTOL = "rtol < 0 illegal."
+const MSG_ATOL_NULL = "atol = NULL illegal."
+const MSG_BAD_ATOL = "Some atol component < 0.0 illegal."
+const MSG_ROOT_FUNC_NULL = "g = NULL illegal."
+const MSG_MISSING_ID = "id = NULL but suppressalg option on."
+const MSG_NO_TOLS = "No integration tolerances have been specified."
+const MSG_FAIL_EWT = "The user-provide EwtSet function failed."
+const MSG_BAD_EWT = "Some initial ewt component = 0.0 illegal."
+const MSG_Y0_FAIL_CONSTR = "y0 fails to satisfy constraints."
+const MSG_LSOLVE_NULL = "The linear solver's solve routine is NULL."
+const MSG_LINIT_FAIL = "The linear solver's init routine failed."
+const MSG_IC_BAD_ICOPT = "icopt has an illegal value."
+const MSG_IC_MISSING_ID = "id = NULL conflicts with icopt."
+const MSG_IC_TOO_CLOSE = "tout1 too close to t0 to attempt initial condition calculation."
+const MSG_IC_BAD_ID = "id has illegal values."
+const MSG_IC_BAD_EWT = "Some initial ewt component = 0.0 illegal."
+const MSG_IC_RES_NONREC = "The residual function failed unrecoverably. "
+const MSG_IC_RES_FAIL = "The residual function failed at the first call. "
+const MSG_IC_SETUP_FAIL = "The linear solver setup failed unrecoverably."
+const MSG_IC_SOLVE_FAIL = "The linear solver solve failed unrecoverably."
+const MSG_IC_NO_RECOVERY = "The residual routine or the linear setup or solve routine had a recoverable error, but IDACalcIC was unable to recover."
+const MSG_IC_FAIL_CONSTR = "Unable to satisfy the inequality constraints."
+const MSG_IC_FAILED_LINS = "The linesearch algorithm failed with too small a step."
+const MSG_IC_CONV_FAILED = "Newton/Linesearch algorithm failed to converge."
+const MSG_YRET_NULL = "yret = NULL illegal."
+const MSG_YPRET_NULL = "ypret = NULL illegal."
+const MSG_TRET_NULL = "tret = NULL illegal."
+const MSG_BAD_ITASK = "itask has an illegal value."
+const MSG_TOO_CLOSE = "tout too close to t0 to start integration."
+const MSG_BAD_HINIT = "Initial step is not towards tout."
+
+# Skipping MacroDefinition: MSG_BAD_TSTOP "The value " MSG_TIME_TSTOP " is behind current " MSG_TIME "in the direction of integration."
+# Skipping MacroDefinition: MSG_CLOSE_ROOTS "Root found at and very near " MSG_TIME "."
+# Skipping MacroDefinition: MSG_MAX_STEPS "At " MSG_TIME ", mxstep steps taken before reaching tout."
+# Skipping MacroDefinition: MSG_EWT_NOW_FAIL "At " MSG_TIME "the user-provide EwtSet function failed."
+# Skipping MacroDefinition: MSG_EWT_NOW_BAD "At " MSG_TIME "some ewt component has become <= 0.0."
+# Skipping MacroDefinition: MSG_TOO_MUCH_ACC "At " MSG_TIME "too much accuracy requested."
+
+const MSG_BAD_K = "Illegal value for k."
+const MSG_NULL_DKY = "dky = NULL illegal."
+const MSG_BAD_T = "Illegal value for t. "
+
+# Skipping MacroDefinition: MSG_BAD_TOUT "Trouble interpolating at " MSG_TIME_TOUT ". tout too far back in direction of integration."
+# Skipping MacroDefinition: MSG_ERR_FAILS "At " MSG_TIME_H "the error test failed repeatedly or with |h| = hmin."
+# Skipping MacroDefinition: MSG_CONV_FAILS "At " MSG_TIME_H "the corrector convergence failed repeatedly or with |h| = hmin."
+# Skipping MacroDefinition: MSG_SETUP_FAILED "At " MSG_TIME "the linear solver setup failed unrecoverably."
+# Skipping MacroDefinition: MSG_SOLVE_FAILED "At " MSG_TIME "the linear solver solve failed unrecoverably."
+# Skipping MacroDefinition: MSG_REP_RES_ERR "At " MSG_TIME "repeated recoverable residual errors."
+# Skipping MacroDefinition: MSG_RES_NONRECOV "At " MSG_TIME "the residual function failed unrecoverably."
+# Skipping MacroDefinition: MSG_FAILED_CONSTR "At " MSG_TIME "unable to satisfy inequality constraints."
+# Skipping MacroDefinition: MSG_RTFUNC_FAILED "At " MSG_TIME ", the rootfinding routine failed in an unrecoverable manner."
+
+const MSG_NO_ROOT = "Rootfinding was not initialized."
+const MSG_INACTIVE_ROOTS = "At the end of the first step, there are still some root functions identically 0. This warning will not be issued again."
+const MSG_NEG_MAXORD = "maxord<=0 illegal."
+const MSG_BAD_MAXORD = "Illegal attempt to increase maximum order."
+const MSG_NEG_HMAX = "hmax < 0 illegal."
+const MSG_NEG_EPCON = "epcon <= 0.0 illegal."
+const MSG_BAD_CONSTR = "Illegal values in constraints vector."
+const MSG_BAD_EPICCON = "epiccon <= 0.0 illegal."
+const MSG_BAD_MAXNH = "maxnh <= 0 illegal."
+const MSG_BAD_MAXNJ = "maxnj <= 0 illegal."
+const MSG_BAD_MAXNIT = "maxnit <= 0 illegal."
+const MSG_BAD_STEPTOL = "steptol <= 0.0 illegal."
+const MSG_TOO_LATE = "IDAGetConsistentIC can only be called before IDASolve."
+
+immutable Array_6_N_Vector
+    d1::N_Vector
+    d2::N_Vector
+    d3::N_Vector
+    d4::N_Vector
+    d5::N_Vector
+    d6::N_Vector
+end
+
+zero(::Type{Array_6_N_Vector}) = begin  # /Users/jgoldfar/.julia/v0.4/Clang/src/wrap_c.jl, line 266:
+        Array_6_N_Vector(fill(zero(N_Vector),6)...)
+    end
+
+type IDAMemRec
+    ida_uround::realtype
+    ida_res::IDAResFn
+    ida_user_data::Ptr{Void}
+    ida_itol::Cint
+    ida_rtol::realtype
+    ida_Satol::realtype
+    ida_Vatol::N_Vector
+    ida_user_efun::Cint
+    ida_efun::IDAEwtFn
+    ida_edata::Ptr{Void}
+    ida_setupNonNull::Cint
+    ida_constraintsSet::Cint
+    ida_suppressalg::Cint
+    ida_phi::Array_6_N_Vector
+    ida_psi::Array_6_realtype
+    ida_alpha::Array_6_realtype
+    ida_beta::Array_6_realtype
+    ida_sigma::Array_6_realtype
+    ida_gamma::Array_6_realtype
+    ida_ewt::N_Vector
+    ida_yy::N_Vector
+    ida_yp::N_Vector
+    ida_delta::N_Vector
+    ida_id::N_Vector
+    ida_constraints::N_Vector
+    ida_savres::N_Vector
+    ida_ee::N_Vector
+    ida_mm::N_Vector
+    ida_tempv1::N_Vector
+    ida_tempv2::N_Vector
+    ida_ynew::N_Vector
+    ida_ypnew::N_Vector
+    ida_delnew::N_Vector
+    ida_dtemp::N_Vector
+    ida_t0::realtype
+    ida_yy0::N_Vector
+    ida_yp0::N_Vector
+    ida_icopt::Cint
+    ida_lsoff::Cint
+    ida_maxnh::Cint
+    ida_maxnj::Cint
+    ida_maxnit::Cint
+    ida_nbacktr::Cint
+    ida_sysindex::Cint
+    ida_epiccon::realtype
+    ida_steptol::realtype
+    ida_tscale::realtype
+    ida_tstopset::Cint
+    ida_tstop::realtype
+    ida_kk::Cint
+    ida_kused::Cint
+    ida_knew::Cint
+    ida_phase::Cint
+    ida_ns::Cint
+    ida_hin::realtype
+    ida_h0u::realtype
+    ida_hh::realtype
+    ida_hused::realtype
+    ida_rr::realtype
+    ida_tn::realtype
+    ida_tretlast::realtype
+    ida_cj::realtype
+    ida_cjlast::realtype
+    ida_cjold::realtype
+    ida_cjratio::realtype
+    ida_ss::realtype
+    ida_epsNewt::realtype
+    ida_epcon::realtype
+    ida_toldel::realtype
+    ida_maxncf::Cint
+    ida_maxcor::Cint
+    ida_maxnef::Cint
+    ida_maxord::Cint
+    ida_maxord_alloc::Cint
+    ida_mxstep::Clong
+    ida_hmax_inv::realtype
+    ida_nst::Clong
+    ida_nre::Clong
+    ida_ncfn::Clong
+    ida_netf::Clong
+    ida_nni::Clong
+    ida_nsetups::Clong
+    ida_lrw1::Clong
+    ida_liw1::Clong
+    ida_lrw::Clong
+    ida_liw::Clong
+    ida_tolsf::realtype
+    ida_ehfun::IDAErrHandlerFn
+    ida_eh_data::Ptr{Void}
+    # ida_errfp::Ptr{Void}
+    ida_errfp::Ptr{Void}
+    ida_SetupDone::Cint
+    ida_VatolMallocDone::Cint
+    ida_constraintsMallocDone::Cint
+    ida_idMallocDone::Cint
+    ida_MallocDone::Cint
+    ida_linit::Ptr{Void}
+    ida_lsetup::Ptr{Void}
+    ida_lsolve::Ptr{Void}
+    ida_lperf::Ptr{Void}
+    ida_lfree::Ptr{Void}
+    ida_lmem::Ptr{Void}
+    ida_linitOK::Cint
+    ida_gfun::IDARootFn
+    ida_nrtfn::Cint
+    ida_iroots::Ptr{Cint}
+    ida_rootdir::Ptr{Cint}
+    ida_tlo::realtype
+    ida_thi::realtype
+    ida_trout::realtype
+    ida_glo::Ptr{realtype}
+    ida_ghi::Ptr{realtype}
+    ida_grout::Ptr{realtype}
+    ida_toutc::realtype
+    ida_ttol::realtype
+    ida_taskc::Cint
+    ida_irfnd::Cint
+    ida_nge::Clong
+    ida_gactive::Ptr{Cint}
+    ida_mxgnull::Cint
+end
+
+typealias IDAMem Ptr{IDAMemRec}
+
+# begin enum ANONYMOUS_31
+typealias ANONYMOUS_31 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_31
+
+# begin enum ANONYMOUS_32
+typealias ANONYMOUS_32 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_32
+
+# begin enum ANONYMOUS_33
+typealias ANONYMOUS_33 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_33
+
+# begin enum ANONYMOUS_34
+typealias ANONYMOUS_34 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_34
+
+# begin enum ANONYMOUS_35
+typealias ANONYMOUS_35 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_35
+
+# begin enum ANONYMOUS_36
+typealias ANONYMOUS_36 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_36
+
+typealias IDABBDLocalFnB Ptr{Void}
+typealias IDABBDCommFnB Ptr{Void}
+
+const IDA_NN = 0
+const IDA_SS = 1
+const IDA_SV = 2
+const IDA_WF = 3
+const IDA_EE = 4
+const MSG_BAD_ISM_CONSTR = "Constraints can not be enforced while forward sensitivity is used with simultaneous method."
+const MSG_NO_QUAD = "Illegal attempt to call before calling IDAQuadInit."
+const MSG_BAD_EWTQ = "Initial ewtQ has component(s) equal to zero (illegal)."
+const MSG_BAD_ITOLQ = "Illegal value for itolQ. The legal values are IDA_SS and IDA_SV."
+const MSG_NO_TOLQ = "No integration tolerances for quadrature variables have been specified."
+const MSG_NULL_ATOLQ = "atolQ = NULL illegal."
+const MSG_BAD_RTOLQ = "rtolQ < 0 illegal."
+const MSG_BAD_ATOLQ = "atolQ has negative component(s) (illegal)."
+const MSG_NO_SENSI = "Illegal attempt to call before calling IDASensInit."
+const MSG_BAD_EWTS = "Initial ewtS has component(s) equal to zero (illegal)."
+const MSG_BAD_ITOLS = "Illegal value for itolS. The legal values are IDA_SS, IDA_SV, and IDA_EE."
+const MSG_NULL_ATOLS = "atolS = NULL illegal."
+const MSG_BAD_RTOLS = "rtolS < 0 illegal."
+const MSG_BAD_ATOLS = "atolS has negative component(s) (illegal)."
+const MSG_BAD_PBAR = "pbar has zero component(s) (illegal)."
+const MSG_BAD_PLIST = "plist has negative component(s) (illegal)."
+const MSG_BAD_NS = "NS <= 0 illegal."
+const MSG_NULL_YYS0 = "yyS0 = NULL illegal."
+const MSG_NULL_YPS0 = "ypS0 = NULL illegal."
+const MSG_BAD_ISM = "Illegal value for ism. Legal values are: IDA_SIMULTANEOUS and IDA_STAGGERED."
+const MSG_BAD_IS = "Illegal value for is."
+const MSG_NULL_DKYA = "dkyA = NULL illegal."
+const MSG_BAD_DQTYPE = "Illegal value for DQtype. Legal values are: IDA_CENTERED and IDA_FORWARD."
+const MSG_BAD_DQRHO = "DQrhomax < 0 illegal."
+const MSG_NULL_ABSTOLQS = "abstolQS = NULL illegal parameter."
+const MSG_BAD_RELTOLQS = "reltolQS < 0 illegal parameter."
+const MSG_BAD_ABSTOLQS = "abstolQS has negative component(s) (illegal)."
+const MSG_NO_QUADSENSI = "Forward sensitivity analysis for quadrature variables was not activated."
+const MSG_NULL_YQS0 = "yQS0 = NULL illegal parameter."
+const MSG_NULL_DKYP = "dkyp = NULL illegal."
+
+# Skipping MacroDefinition: MSG_EWTQ_NOW_BAD "At " MSG_TIME ", a component of ewtQ has become <= 0."
+# Skipping MacroDefinition: MSG_QRHSFUNC_FAILED "At " MSG_TIME ", the quadrature right-hand side routine failed in an unrecoverable manner."
+# Skipping MacroDefinition: MSG_QRHSFUNC_UNREC "At " MSG_TIME ", the quadrature right-hand side failed in a recoverable manner, but no recovery is possible."
+# Skipping MacroDefinition: MSG_QRHSFUNC_REPTD "At " MSG_TIME "repeated recoverable quadrature right-hand side function errors."
+
+const MSG_QRHSFUNC_FIRST = "The quadrature right-hand side routine failed at the first call."
+const MSG_NULL_P = "p = NULL when using internal DQ for sensitivity residual is illegal."
+
+# Skipping MacroDefinition: MSG_EWTS_NOW_BAD "At " MSG_TIME ", a component of ewtS has become <= 0."
+# Skipping MacroDefinition: MSG_SRHSFUNC_FAILED "At " MSG_TIME ", the sensitivity residual routine failed in an unrecoverable manner."
+# Skipping MacroDefinition: MSG_SRHSFUNC_UNREC "At " MSG_TIME ", the sensitivity residual failed in a recoverable manner, but no recovery is possible."
+# Skipping MacroDefinition: MSG_SRHSFUNC_REPTD "At " MSG_TIME "repeated recoverable sensitivity residual function errors."
+
+const MSG_NO_TOLQS = "No integration tolerances for quadrature sensitivity variables have been specified."
+const MSG_NULL_RHSQ = "IDAS is expected to use DQ to evaluate the RHS of quad. sensi., but quadratures were not initialized."
+const MSG_BAD_EWTQS = "Initial ewtQS has component(s) equal to zero (illegal)."
+
+# Skipping MacroDefinition: MSG_EWTQS_NOW_BAD "At " MSG_TIME ", a component of ewtQS has become <= 0."
+# Skipping MacroDefinition: MSG_QSRHSFUNC_FAILED "At " MSG_TIME ", the sensitivity quadrature right-hand side routine failed in an unrecoverable manner."
+
+const MSG_QSRHSFUNC_FIRST = "The quadrature right-hand side routine failed at the first call."
+const MSGAM_NULL_IDAMEM = "ida_mem = NULL illegal."
+const MSGAM_NO_ADJ = "Illegal attempt to call before calling IDAadjInit."
+const MSGAM_BAD_INTERP = "Illegal value for interp."
+const MSGAM_BAD_STEPS = "Steps nonpositive illegal."
+const MSGAM_BAD_WHICH = "Illegal value for which."
+const MSGAM_NO_BCK = "No backward problems have been defined yet."
+const MSGAM_NO_FWD = "Illegal attempt to call before calling IDASolveF."
+const MSGAM_BAD_TB0 = "The initial time tB0 is outside the interval over which the forward problem was solved."
+const MSGAM_BAD_SENSI = "At least one backward problem requires sensitivities, but they were not stored for interpolation."
+const MSGAM_BAD_ITASKB = "Illegal value for itaskB. Legal values are IDA_NORMAL and IDA_ONE_STEP."
+const MSGAM_BAD_TBOUT = "The final time tBout is outside the interval over which the forward problem was solved."
+const MSGAM_BACK_ERROR = "Error occured while integrating backward problem # %d"
+const MSGAM_BAD_TINTERP = "Bad t = %g for interpolation."
+const MSGAM_BAD_T = "Bad t for interpolation."
+const MSGAM_WRONG_INTERP = "This function cannot be called for the specified interp type."
+const MSGAM_MEM_FAIL = "A memory request failed."
+const MSGAM_NO_INITBS = "Illegal attempt to call before calling IDAInitBS."
+
+immutable Array_6_Ptr
+    d1::Ptr{N_Vector}
+    d2::Ptr{N_Vector}
+    d3::Ptr{N_Vector}
+    d4::Ptr{N_Vector}
+    d5::Ptr{N_Vector}
+    d6::Ptr{N_Vector}
+end
+
+zero(::Type{Array_6_Ptr}) = begin  # /Users/jgoldfar/.julia/v0.4/Clang/src/wrap_c.jl, line 266:
+        Array_6_Ptr(fill(zero(Ptr{N_Vector}),6)...)
+    end
+
+type IDABMemRec
+    ida_index::Cint
+    ida_t0::realtype
+    IDA_mem::IDAMem
+    ida_res_withSensi::Cint
+    ida_rhsQ_withSensi::Cint
+    ida_res::IDAResFnB
+    ida_resS::IDAResFnBS
+    ida_rhsQ::IDAQuadRhsFnB
+    ida_rhsQS::IDAQuadRhsFnBS
+    ida_user_data::Ptr{Void}
+    ida_lmem::Ptr{Void}
+    ida_lfree::Ptr{Void}
+    ida_pmem::Ptr{Void}
+    ida_pfree::Ptr{Void}
+    ida_tout::realtype
+    ida_yy::N_Vector
+    ida_yp::N_Vector
+    ida_next::Ptr{IDABMemRec}
+end
+
+typealias IDAAStorePntFn Ptr{Void}
+typealias IDAAGetYFn Ptr{Void}
+typealias IDAAMMallocFn Ptr{Void}
+typealias IDAAMFreeFn Ptr{Void}
+
+type IDAadjMemRec
+    ia_tinitial::realtype
+    ia_tfinal::realtype
+    ia_firstIDAFcall::Cint
+    ia_tstopIDAFcall::Cint
+    ia_tstopIDAF::realtype
+    IDAB_mem::Ptr{IDABMemRec}
+    ia_nbckpbs::Cint
+    ia_bckpbCrt::Ptr{IDABMemRec}
+    ia_firstIDABcall::Cint
+    ck_mem::Ptr{CkpntMemRec}
+    ia_ckpntData::Ptr{CkpntMemRec}
+    ia_nckpnts::Cint
+    ia_nsteps::Clong
+    dt_mem::Ptr{Ptr{DtpntMemRec}}
+    ia_np::Clong
+    ia_interpType::Cint
+    ia_storePnt::IDAAStorePntFn
+    ia_getY::IDAAGetYFn
+    ia_malloc::IDAAMMallocFn
+    ia_free::IDAAMFreeFn
+    ia_mallocDone::Cint
+    ia_newData::Cint
+    ia_storeSensi::Cint
+    ia_interpSensi::Cint
+    ia_noInterp::Cint
+    ia_Y::Array_6_N_Vector
+    ia_YS::Array_6_Ptr
+    ia_T::Array_6_realtype
+    ia_yyTmp::N_Vector
+    ia_ypTmp::N_Vector
+    ia_yySTmp::Ptr{N_Vector}
+    ia_ypSTmp::Ptr{N_Vector}
+end
+
+typealias IDAadjMem Ptr{IDAadjMemRec}
+typealias IDABMem Ptr{IDABMemRec}
+
+# begin enum ANONYMOUS_37
+typealias ANONYMOUS_37 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_37
+
+# begin enum ANONYMOUS_38
+typealias ANONYMOUS_38 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_38
+
+# begin enum ANONYMOUS_39
+typealias ANONYMOUS_39 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_39
+
+# begin enum ANONYMOUS_40
+typealias ANONYMOUS_40 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_40
+
+# begin enum ANONYMOUS_41
+typealias ANONYMOUS_41 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_41
+
+# begin enum ANONYMOUS_42
+typealias ANONYMOUS_42 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_42
+
+const KINBBDPRE_SUCCESS = 0
+const KINBBDPRE_PDATA_NULL = -11
+const KINBBDPRE_FUNC_UNRECVR = -12
+
+typealias KINCommFn Ptr{Void}
+typealias KINLocalFn Ptr{Void}
+
+const PRINTFL_DEFAULT = 0
+const MXITER_DEFAULT = 200
+const MXNBCF_DEFAULT = 10
+const MSBSET_DEFAULT = 10
+const MSBSET_SUB_DEFAULT = 5
+
+# Skipping MacroDefinition: OMEGA_MIN RCONST ( 0.00001 )
+# Skipping MacroDefinition: OMEGA_MAX RCONST ( 0.9 )
+
+const MSG_FUNC_NULL = "func = NULL illegal."
+const MSG_BAD_PRINTFL = "Illegal value for printfl."
+const MSG_BAD_MXITER = "Illegal value for mxiter."
+const MSG_BAD_MSBSET = "Illegal msbset < 0."
+const MSG_BAD_MSBSETSUB = "Illegal msbsetsub < 0."
+const MSG_BAD_ETACHOICE = "Illegal value for etachoice."
+const MSG_BAD_ETACONST = "eta out of range."
+const MSG_BAD_GAMMA = "gamma out of range."
+const MSG_BAD_ALPHA = "alpha out of range."
+const MSG_BAD_MXNEWTSTEP = "Illegal mxnewtstep < 0."
+const MSG_BAD_RELFUNC = "relfunc < 0 illegal."
+const MSG_BAD_FNORMTOL = "fnormtol < 0 illegal."
+const MSG_BAD_SCSTEPTOL = "scsteptol < 0 illegal."
+const MSG_BAD_MXNBCF = "mxbcf < 0 illegal."
+const MSG_BAD_CONSTRAINTS = "Illegal values in constraints vector."
+const MSG_BAD_OMEGA = "scalars < 0 illegal."
+const MSG_LSOLV_NO_MEM = "The linear solver memory pointer is NULL."
+const MSG_UU_NULL = "uu = NULL illegal."
+const MSG_BAD_GLSTRAT = "Illegal value for global strategy."
+const MSG_BAD_USCALE = "uscale = NULL illegal."
+const MSG_USCALE_NONPOSITIVE = "uscale has nonpositive elements."
+const MSG_BAD_FSCALE = "fscale = NULL illegal."
+const MSG_FSCALE_NONPOSITIVE = "fscale has nonpositive elements."
+const MSG_INITIAL_CNSTRNT = "Initial guess does NOT meet constraints."
+const MSG_SYSFUNC_FAILED = "The system function failed in an unrecoverable manner."
+const MSG_SYSFUNC_FIRST = "The system function failed at the first call."
+const MSG_LSETUP_FAILED = "The linear solver's setup function failed in an unrecoverable manner."
+const MSG_LSOLVE_FAILED = "The linear solver's solve function failed in an unrecoverable manner."
+const MSG_LINSOLV_NO_RECOVERY = "The linear solver's solve function failed recoverably, but the Jacobian data is already current."
+const MSG_LINESEARCH_NONCONV = "The line search algorithm was unable to find an iterate sufficiently distinct from the current iterate."
+const MSG_LINESEARCH_BCFAIL = "The line search algorithm was unable to satisfy the beta-condition for nbcfails iterations."
+const MSG_MAXITER_REACHED = "The maximum number of iterations was reached before convergence."
+const MSG_MXNEWT_5X_EXCEEDED = "Five consecutive steps have been taken that satisfy a scaled step length test."
+const MSG_SYSFUNC_REPTD = "Unable to correct repeated recoverable system function errors."
+const INFO_RETVAL = "Return value: %d"
+const INFO_ADJ = "no. of lambda adjustments = %ld"
+const INFO_NNI = "nni = %4ld   nfe = %6ld   fnorm = %26.16lg"
+const INFO_TOL = "scsteptol = %12.3lg  fnormtol = %12.3lg"
+const INFO_FMAX = "scaled f norm (for stopping) = %12.3lg"
+const INFO_PNORM = "pnorm = %12.4le"
+const INFO_PNORM1 = "(ivio=1) pnorm = %12.4le"
+const INFO_FNORM = "fnorm(L2) = %20.8le"
+const INFO_LAM = "min_lam = %11.4le   f1norm = %11.4le   pnorm = %11.4le"
+const INFO_ALPHA = "fnorm = %15.8le   f1norm = %15.8le   alpha_cond = %15.8le  lam = %15.8le"
+const INFO_BETA = "f1norm = %15.8le   beta_cond = %15.8le   lam = %15.8le"
+const INFO_ALPHABETA = "f1norm = %15.8le  alpha_cond = %15.8le  beta_cond = %15.8le  lam = %15.8le"
+
+type KINMemRec
+    kin_uround::realtype
+    kin_func::KINSysFn
+    kin_user_data::Ptr{Void}
+    kin_fnormtol::realtype
+    kin_scsteptol::realtype
+    kin_globalstrategy::Cint
+    kin_printfl::Cint
+    kin_mxiter::Clong
+    kin_msbset::Clong
+    kin_msbset_sub::Clong
+    kin_mxnbcf::Clong
+    kin_etaflag::Cint
+    kin_noMinEps::Cint
+    kin_setupNonNull::Cint
+    kin_constraintsSet::Cint
+    kin_jacCurrent::Cint
+    kin_callForcingTerm::Cint
+    kin_noResMon::Cint
+    kin_retry_nni::Cint
+    kin_update_fnorm_sub::Cint
+    kin_mxnewtstep::realtype
+    kin_sqrt_relfunc::realtype
+    kin_stepl::realtype
+    kin_stepmul::realtype
+    kin_eps::realtype
+    kin_eta::realtype
+    kin_eta_gamma::realtype
+    kin_eta_alpha::realtype
+    kin_noInitSetup::Cint
+    kin_sthrsh::realtype
+    kin_nni::Clong
+    kin_nfe::Clong
+    kin_nnilset::Clong
+    kin_nnilset_sub::Clong
+    kin_nbcf::Clong
+    kin_nbktrk::Clong
+    kin_ncscmx::Clong
+    kin_uu::N_Vector
+    kin_unew::N_Vector
+    kin_fval::N_Vector
+    kin_uscale::N_Vector
+    kin_fscale::N_Vector
+    kin_pp::N_Vector
+    kin_constraints::N_Vector
+    kin_vtemp1::N_Vector
+    kin_vtemp2::N_Vector
+    kin_lrw1::Clong
+    kin_liw1::Clong
+    kin_lrw::Clong
+    kin_liw::Clong
+    kin_linit::Ptr{Void}
+    kin_lsetup::Ptr{Void}
+    kin_lsolve::Ptr{Void}
+    kin_lfree::Ptr{Void}
+    kin_inexact_ls::Cint
+    kin_lmem::Ptr{Void}
+    kin_fnorm::realtype
+    kin_f1norm::realtype
+    kin_res_norm::realtype
+    kin_sfdotJp::realtype
+    kin_sJpnorm::realtype
+    kin_fnorm_sub::realtype
+    kin_eval_omega::Cint
+    kin_omega::realtype
+    kin_omega_min::realtype
+    kin_omega_max::realtype
+    kin_MallocDone::Cint
+    kin_ehfun::KINErrHandlerFn
+    kin_eh_data::Ptr{Void}
+    # kin_errfp::Ptr{Void}
+    kin_errfp::Ptr{Void}
+    kin_ihfun::KINInfoHandlerFn
+    kin_ih_data::Ptr{Void}
+    # kin_infofp::Ptr{Void}
+    kin_infofp::Ptr{Void}
+end
+
+typealias KINMem Ptr{KINMemRec}
+
+# begin enum ANONYMOUS_43
+typealias ANONYMOUS_43 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_43
+
+# begin enum ANONYMOUS_44
+typealias ANONYMOUS_44 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_44
+
+# begin enum ANONYMOUS_45
+typealias ANONYMOUS_45 UInt32
+const PREC_NONE = (UInt32)(0)
+const PREC_LEFT = (UInt32)(1)
+const PREC_RIGHT = (UInt32)(2)
+const PREC_BOTH = (UInt32)(3)
+# end enum ANONYMOUS_45
+
+# begin enum ANONYMOUS_46
+typealias ANONYMOUS_46 UInt32
+const MODIFIED_GS = (UInt32)(1)
+const CLASSICAL_GS = (UInt32)(2)
+# end enum ANONYMOUS_46

--- a/src/wrap_sundials.jl
+++ b/src/wrap_sundials.jl
@@ -1,12 +1,34 @@
 # This file is not an active part of the package. This is the code
 # that uses the Clang.jl package to wrap Sundials using the headers.
 
-cd("/home/tshort/tmp/sund")
-ENV["JULIAHOME"] = "/home/tshort/julia/jul"
+# Find all headers
+incpath = Pkg.dir("Sundials", "deps", "usr", "include")
+if !isdir(incpath)
+  error("Run Pkg.build(\"Sundials\") before trying to wrap C headers.")
+end
+
+wdir = Pkg.dir("Sundials", "new")
+mkpath(wdir)
+cd(wdir)
+
+sundials_names = ["nvector", "sundials", "cvode", "cvodes", "ida", "idas", "kinsol"]
+if isdir(joinpath(incpath, "arkode"))
+  push!(sundials_names, "arkode")
+end
+headers = ASCIIString[]
+for name in sundials_names
+    path = joinpath(incpath, name)
+    append!(headers, map(x->joinpath(path, x),split(readall(pipeline(`ls $path`, `sort`)))))
+end
+# @show headers
+
+
+## Do wrapping using Clang.jl
+ENV["JULIAHOME"] = "/Users/jgoldfar/Public/julia/usr/"
 
 using Clang.wrap_c
 
-if (!has(ENV, "JULIAHOME"))
+if (!haskey(ENV, "JULIAHOME"))
   error("Please set JULIAHOME variable to the root of your julia install")
 end
 
@@ -18,12 +40,15 @@ clang_includes = map(x->joinpath(ENV["JULIAHOME"], x), [
   "deps/llvm-3.2/include/"
   ])
 
-sundials_names = ["nvector", "sundials", "cvode", "cvodes", "ida", "idas", "kinsol"]
-check_use_header(path) = true
-for name in sundials_names
-    path = joinpath("/usr/local/include/", name)
-    headers = map(x->joinpath(path, x),split(readall(`ls $path` | `sort`)) )
-    @show headers
-    wrap_c.wrap_c_headers(headers, [clang_includes, path], ASCIIString[], check_use_header, "$name.jl")
-end
-mv("sundials.jl", "libsundials.jl")  # avoid a name conflict for case-insensitive file systems
+# check_use_header(path) = true
+header_file(str::AbstractString) = string(basename(dirname(str)), ".jl")
+header_library_file(str::AbstractString) = "shlib"
+clang_extraargs = [
+"-D", "__STDC_LIMIT_MACROS", "-D", "__STDC_CONSTANT_MACROS", 
+"-v"]
+context = wrap_c.init(
+common_file="sundials_h.jl", 
+clang_args = clang_extraargs, clang_diagnostics = true, clang_includes = [clang_includes; incpath], header_outputfile = header_file)
+context.headers = headers
+run(context)
+mv(joinpath(wdir, "sundials.jl"), joinpath(wdir, "libsundials.jl"))  # avoid a name conflict for case-insensitive file systems


### PR DESCRIPTION
Following issue #54. This fixes the changed syntax for 0.4, as well as the simple Sundials.jl wrapper functions.