### PR TITLE
Make high level wrappers check for errors, and make IDA initial value solver usable with idasol

### DIFF
--- a/src/Sundials.jl
+++ b/src/Sundials.jl
@@ -227,6 +227,20 @@ end
 ##################################################################
 
 
+macro checkflag(ex)
+    # Insert a check that the given function call returns 0,
+    # throw an error otherwise. Only apply directly to function calls.
+    @assert Base.Meta.isexpr(ex, :call)
+    fname = ex.args[1]
+    quote
+        flag = $(esc(ex))
+        if flag != 0
+            error($(string(fname, " failed with error code = ")), flag)
+        end
+        flag
+    end
+end
+
 @c Int32 KINSetUserData (Ptr{:Void},Any) libsundials_kinsol  ## needed to allow passing a Function through the user data
 
 function kinsolfun(y::N_Vector, fy::N_Vector, userfun::Function)
@@ -243,24 +257,29 @@ function kinsol(f::Function, y0::Vector{Float64})
     # return: the solution vector
     neq = length(y0)
     kmem = KINCreate()
-    # use the user_data field to pass a function
-    #   see: https://github.com/JuliaLang/julia/issues/2554
-    flag = KINInit(kmem, cfunction(kinsolfun, Int32, (N_Vector, N_Vector, Ref{Function})), nvector(y0))
-    flag = KINDense(kmem, neq)
-    flag = KINSetUserData(kmem, f)
-    ## Solve problem
-    scale = ones(neq)
-    strategy = 0   # KIN_NONE
-    y = copy(y0)
-    flag = Sundials.KINSol(kmem,
-                           y,
-                           strategy,
-                           scale,
-                           scale)
-    if flag != 0
-        println("KINSol error found")
+    if kmem == C_NULL
+        error("Failed to allocate KINSOL solver object")
     end
-    KINFree([kmem])
+
+    y = copy(y0)
+    try
+        # use the user_data field to pass a function
+        #   see: https://github.com/JuliaLang/julia/issues/2554
+        flag = @checkflag KINInit(kmem, cfunction(kinsolfun, Int32, (N_Vector, N_Vector, Ref{Function})), nvector(y0))
+        flag = @checkflag KINDense(kmem, neq)
+        flag = @checkflag KINSetUserData(kmem, f)
+        ## Solve problem
+        scale = ones(neq)
+        strategy = 0   # KIN_NONE
+        flag = @checkflag KINSol(kmem,
+                                 y,
+                                 strategy,
+                                 scale,
+                                 scale)
+    finally
+        KINFree([kmem])
+    end
+
     return y
 end
 
@@ -274,8 +293,10 @@ function cvodefun(t::Float64, y::N_Vector, yp::N_Vector, userfun::Function)
 end
 
 function cvode(f::Function, y0::Vector{Float64}, t::Vector{Float64}; reltol::Float64=1e-4, abstol::Float64=1e-6)
-    # f, Function to be optimized of the form f(y::Vector{Float64}, fy::Vector{Float64}, t::Float64)
-    #    where `y` is the input vector, and `fy` is the
+    # f, Function of the form
+    #         f(t, y::Vector{Float64}, yp::Vector{Float64})
+    #     where `y` is the input state vector, and `yp` is the output vector
+    #     of time derivatives for the states `y`
     # y0, Vector of initial values
     # t, Vector of time values at which to record integration results
     # reltol, Relative Tolerance to be used (default=1e-4)
@@ -284,19 +305,26 @@ function cvode(f::Function, y0::Vector{Float64}, t::Vector{Float64}; reltol::Flo
     #         state variable `y` along columns
     neq = length(y0)
     mem = CVodeCreate(CV_BDF, CV_NEWTON)
-    flag = CVodeInit(mem, cfunction(cvodefun, Int32, (realtype, N_Vector, N_Vector, Ref{Function})), t[1], nvector(y0))
-    flag = CVodeSetUserData(mem, f)
-    flag = CVodeSStolerances(mem, reltol, abstol)
-    flag = CVDense(mem, neq)
-    yres = zeros(length(t), length(y0))
-    yres[1,:] = y0
-    y = copy(y0)
-    tout = [0.0]
-    for k in 2:length(t)
-        flag = CVode(mem, t[k], y, tout, CV_NORMAL)
-        yres[k,:] = y
+    if mem == C_NULL
+        error("Failed to allocate CVODE solver object")
     end
-    CVodeFree([mem])
+
+    yres = zeros(length(t), length(y0))
+    try
+        flag = @checkflag CVodeInit(mem, cfunction(cvodefun, Int32, (realtype, N_Vector, N_Vector, Ref{Function})), t[1], nvector(y0))
+        flag = @checkflag CVodeSetUserData(mem, f)
+        flag = @checkflag CVodeSStolerances(mem, reltol, abstol)
+        flag = @checkflag CVDense(mem, neq)
+        yres[1,:] = y0
+        y = copy(y0)
+        tout = [0.0]
+        for k in 2:length(t)
+            flag = @checkflag CVode(mem, t[k], y, tout, CV_NORMAL)
+            yres[k,:] = y
+        end
+    finally
+        CVodeFree([mem])
+    end
     return yres
 end
 
@@ -310,39 +338,55 @@ function idasolfun(t::Float64, y::N_Vector, yp::N_Vector, r::N_Vector, userfun::
     return Int32(0)   # indicates normal return
 end
 
-function idasol(f::Function, y0::Vector{Float64}, yp0::Vector{Float64}, t::Vector{Float64}; reltol::Float64=1e-4, abstol::Float64=1e-6)
-    # f, Function to be optimized of the form f(y::Vector{Float64}, fy::Vector{Float64})
-    #    where `y` is the input vector, and `fy` is the
+function idasol(f::Function, y0::Vector{Float64}, yp0::Vector{Float64}, t::Vector{Float64};
+        reltol::Float64=1e-4, abstol::Float64=1e-6, diffstates::Union{Vector{Bool},Void}=nothing)
+    # f, Function of the form
+    #         f(t, y::Vector{Float64}, yp::Vector{Float64}, r::Vector{Float64})
+    #     where `y` and `yp` are the input state and derivative vectors,
+    #     and `r` is the output residual vector
     # y0, Vector of initial values
     # yp0, Vector of initial values of the derivatives
     # reltol, Relative Tolerance to be used (default=1e-4)
     # abstol, Absolute Tolerance to be used (default=1e-6)
+    # diffstates, Boolean vector, true for the positions such that `r` depends on `yp[k]`
     # return: (y,yp) two solution matrices representing the states and state derivatives
     #         with time steps in `t` along rows and state variable `y` or `yp` along columns
     neq = length(y0)
     mem = IDACreate()
-    flag = IDAInit(mem, cfunction(idasolfun, Int32, (realtype, N_Vector, N_Vector, N_Vector, Ref{Function})), t[1], nvector(y0), nvector(yp0))
-    flag = IDASetUserData(mem, f)
-    flag = IDASStolerances(mem, reltol, abstol)
-    flag = IDADense(mem, neq)
-    rtest = zeros(neq)
-    f(t[1], y0, yp0, rtest)
-    if any(abs(rtest) .>= reltol)
-        flag = IDACalcIC(mem, Sundials.IDA_YA_YDP_INIT, t[1] + tstep)
+    if mem == C_NULL
+        error("Failed to allocate IDA solver object")
     end
+
     yres = zeros(length(t), length(y0))
     ypres = zeros(length(t), length(y0))
-    yres[1,:] = y0
-    ypres[1,:] = yp0
-    y = copy(y0)
-    yp = copy(yp0)
-    tout = [0.0]
-    for k in 2:length(t)
-        retval = Sundials.IDASolve(mem, t[k], tout, y, yp, IDA_NORMAL)
-        yres[k,:] = y
-        ypres[k,:] = yp
+    try
+        flag = @checkflag IDAInit(mem, cfunction(idasolfun, Int32, (realtype, N_Vector, N_Vector, N_Vector, Ref{Function})), t[1], nvector(y0), nvector(yp0))
+        flag = @checkflag IDASetUserData(mem, f)
+        flag = @checkflag IDASStolerances(mem, reltol, abstol)
+        flag = @checkflag IDADense(mem, neq)
+        rtest = zeros(neq)
+        f(t[1], y0, yp0, rtest)
+        if any(abs(rtest) .>= reltol)
+            if diffstates === nothing
+                error("Must supply diffstates argument to use IDA initial value solver.")
+            end
+            flag = @checkflag IDASetId(mem, collect(Float64, diffstates))
+            flag = @checkflag IDACalcIC(mem, IDA_YA_YDP_INIT, t[2])
+        end
+        yres[1,:] = y0
+        ypres[1,:] = yp0
+        y = copy(y0)
+        yp = copy(yp0)
+        tout = [0.0]
+        for k in 2:length(t)
+            retval = @checkflag IDASolve(mem, t[k], tout, y, yp, IDA_NORMAL)
+            yres[k,:] = y
+            ypres[k,:] = yp
+        end
+    finally
+        IDAFree([mem])
     end
-    IDAFree([mem])
+
     return yres, ypres
 end
 


### PR DESCRIPTION
This pull request contains two fixes:

* Checking for errors within the high level wrappers `kinsol`, `cvode`, and `idasol`, and
* Making it possible to use IDA's initial value solver with `idasol`

These aren't really related except for that they touch the same code, so please tell me if I should split up the pull request.

The function `idasol` calls IDA's `IDACalcIC` to calculate consistent initial conditions if the ones supplied arent't consistent up to the given accuracy. But `IDACalcIC` needs to know which states are differential states to be able to do this, and currently just returns with an error. This PR adds an optional boolean vector argument `diffstate` to `idasol` to be able to specify which states are algebraic (false) vs. differential (true), so that the initial value solver can actually be used through `idasol`.
