### PR TITLE
Fixed examples

### DIFF
--- a/examples/cvode_Roberts_dns.jl
+++ b/examples/cvode_Roberts_dns.jl
@@ -1,7 +1,7 @@
 
 using Sundials
 
-## f routine. Compute function f(t,y). 
+## f routine. Compute function f(t,y).
 
 function f(t, y, ydot, user_data)
     y = Sundials.asarray(y)
@@ -13,7 +13,7 @@ function f(t, y, ydot, user_data)
 end
 
 
-## g routine. Compute functions g_i(t,y) for i = 0,1. 
+## g routine. Compute functions g_i(t,y) for i = 0,1.
 
 function g(t, y, gout, user_data)
     y = Sundials.asarray(y)
@@ -23,7 +23,7 @@ function g(t, y, gout, user_data)
     return Int32(0)
 end
 
-## Jacobian routine. Compute J(t,y) = df/dy.  
+## Jacobian routine. Compute J(t,y) = df/dy.
 
 # Using StrPack
 # -- it works
@@ -31,7 +31,7 @@ end
 # Note: this is for Sundials v 2.4; the structure changed for v 2.5
 # Because of this, I'm commenting this out.
 ## using StrPack
-## @struct type J_DlsMat    
+## @struct type J_DlsMat
 ##     typ::Int32
 ##     M::Int32
 ##     N::Int32
@@ -45,7 +45,7 @@ end
 ## end
 # Note: Here is the (untested) structure for v 2.5
 ## using StrPack
-## @struct type J_DlsMat    
+## @struct type J_DlsMat
 ##     typ::Int32
 ##     M::Int
 ##     N::Int
@@ -69,14 +69,14 @@ function Jac(N, t, y, fy, Jptr, user_data,
     J[1,1] = -0.04
     J[1,2] = 1.0e4*y[3]
     J[1,3] = 1.0e4*y[2]
-    J[2,1] = 0.04 
+    J[2,1] = 0.04
     J[2,2] = -1.0e4*y[3] - 6.0e7*y[2]
     J[2,3] = -1.0e4*y[2]
     J[3,2] = 6.0e7*y[2]
     return Int32(0)
 end
 
-neq = Int32(3)
+neq = 3
 
 t0 = 0.0
 t1 = 0.4
@@ -89,7 +89,7 @@ abstol = [1e-8, 1e-14, 1e-6]
 cvode_mem = Sundials.CVodeCreate(Sundials.CV_BDF, Sundials.CV_NEWTON)
 flag = Sundials.CVodeInit(cvode_mem, f, t0, y)
 flag = Sundials.CVodeSVtolerances(cvode_mem, reltol, abstol)
-flag = Sundials.CVodeRootInit(cvode_mem, Int32(2), g)
+flag = Sundials.CVodeRootInit(cvode_mem, 2, g)
 flag = Sundials.CVDense(cvode_mem, neq)
 ## flag = Sundials.CVDlsSetDenseJacFn(cvode_mem, Jac)  # works, but clunky, see above
 
@@ -103,7 +103,7 @@ while true
     flag = Sundials.CVode(cvode_mem, tout, y, t, Sundials.CV_NORMAL)
     println("T = ", tout, ", Y = ", y)
     if flag == Sundials.CV_ROOT_RETURN
-        flagr = Sundials.CVodeGetRootInfo(cvode_mem, rootsfound)
+        flagr = Sundials.CVodeGetRootInfo(cvode_mem, pointer(rootsfound))
         println("roots = ", rootsfound)
     end
     if flag == Sundials.CV_SUCCESS

--- a/examples/ida_Cable.jl
+++ b/examples/ida_Cable.jl
@@ -24,9 +24,9 @@ xsteps = round(Int,L/dx)
 ## Number of timesteps to simulate
 tf = 10.0
 dt = 0.1
-timesteps = int(tf/dt)
+timesteps = round(Int, tf/dt)
 t = 0.0:dt:(dt*(timesteps-1))
-    
+
 d = 4.0 * 1e-4 ## Cable diameter in cm
 R_m = 2.5e11 ## Membrane resistance in Ohms/cm^2
 G_m = 1.0/R_m ## Membrane conductance
@@ -41,7 +41,7 @@ I_in = 0.1
 I_delay = 1.0
 ## Duration of injected current
 I_dur = 5.0
-J[max(1,int((I_delay)/dt)):int((I_delay+I_dur)/dt),int(1*xsteps/2)] = I_in
+J[max(1,round(Int,(I_delay)/dt)):round(Int,(I_delay+I_dur)/dt),round(Int,1*xsteps/2)] = I_in
 
 G_J = map(i -> CoordInterpGrid(t, vec(J[:,i]), 0.0, InterpQuadratic),1:xsteps)
 
@@ -53,18 +53,18 @@ G_J = map(i -> CoordInterpGrid(t, vec(J[:,i]), 0.0, InterpQuadratic),1:xsteps)
 ##
 
 function cableres(t, u, up, r)
-    
+
     r[:] = u ## Initialize r to u, to take care of boundary equations.
-    
+
     ## Loop over segments; set res = up - (central difference).
     for i = 2:(xsteps-2)
         loc = i
         r[loc] = C_m * up[loc] - (d/(4*R_i)) * (u[loc-1] + u[loc+1] -
                                                 2.0 * u[loc]) +
                  G_m * u[loc] - R_m * (G_J[loc])[t]
-        
+
     end
-    
+
     return (0)
 end
 
@@ -73,8 +73,8 @@ function initial()
 
     u = zeros(xsteps)
 
-    u[2:xsteps-2] = -60.0 ## initial value -60 mV 
-    
+    u[2:xsteps-2] = -60.0 ## initial value -60 mV
+
     id = ones(xsteps)
 
     up = zeros(xsteps)
@@ -82,11 +82,11 @@ function initial()
 
     cableres(0.0, u, up, r)
 
-    ## Copy -res into up to get correct interior initial up values. 
+    ## Copy -res into up to get correct interior initial up values.
     up[:] = -1.0 * r
 
     return (u,up,id)
-    
+
 end
 
 nvector = Sundials.nvector

--- a/examples/ida_Roberts_dns.jl
+++ b/examples/ida_Roberts_dns.jl
@@ -10,8 +10,8 @@
 ##  * Programmer(s): Allan Taylor, Alan Hindmarsh and
 ##  *                Radu Serban @ LLNL
 ##  * -----------------------------------------------------------------
-##  * This simple example problem for IDA, due to Robertson, 
-##  * is from chemical kinetics, and consists of the following three 
+##  * This simple example problem for IDA, due to Robertson,
+##  * is from chemical kinetics, and consists of the following three
 ##  * equations:
 ##  *
 ##  *      dy1/dt = -.04*y1 + 1.e4*y2*y3
@@ -34,10 +34,10 @@
 using Sundials
 
 
-## Define the system residual function. 
+## Define the system residual function.
 function resrob(tres, yy, yp, rr, user_data)
-    yval = Sundials.asarray(yy) 
-    ypval = Sundials.asarray(yp) 
+    yval = Sundials.asarray(yy)
+    ypval = Sundials.asarray(yp)
     rval = Sundials.asarray(rr)
     rval[1]  = -0.04*yval[1] + 1.0e4*yval[2]*yval[3]
     rval[2]  = -rval[1] - 3.0e7*yval[2]*yval[2] - ypval[2]
@@ -46,9 +46,9 @@ function resrob(tres, yy, yp, rr, user_data)
     return Int32(0)   # indicates normal return
 end
 
-## Root function routine. Compute functions g_i(t,y) for i = 0,1. 
+## Root function routine. Compute functions g_i(t,y) for i = 0,1.
 function grob(t, yy, yp, gout, user_data)
-    yval = Sundials.asarray(yy) 
+    yval = Sundials.asarray(yy)
     gval = Sundials.asarray(gout, (2,))
     gval[1] = yval[1] - 0.0001
     gval[2] = yval[3] - 0.01
@@ -72,7 +72,7 @@ function jacrob(Neq, tt, cj, yy, yp, resvec,
     return Int32(0)   # indicates normal return
 end
 
-neq = Int32(3)
+neq = 3
 nout = 12
 t0 = 0.0
 yy = [1.0,0.0,0.0]
@@ -86,7 +86,7 @@ retval = Sundials.IDAInit(mem, resrob, t0, yy, yp)
 retval = Sundials.IDASVtolerances(mem, rtol, avtol)
 
 ## Call IDARootInit to specify the root function grob with 2 components
-retval = Sundials.IDARootInit(mem, Int32(2), grob)
+retval = Sundials.IDARootInit(mem, 2, grob)
 
 ## Call IDADense and set up the linear solver.
 retval = Sundials.IDADense(mem, neq)
@@ -97,17 +97,16 @@ tout = tout1
 tret = [1.0]
 rootsfound = round(Int32,[0, 0])
 
-while true 
+while true
     retval = Sundials.IDASolve(mem, tout, tret, yy, yp, Sundials.IDA_NORMAL)
     println("T = ", tout, ", Y = ", yy)
-    if retval == Sundials.IDA_ROOT_RETURN 
-        retvalr = Sundials.IDAGetRootInfo(mem, rootsfound)
+    if retval == Sundials.IDA_ROOT_RETURN
+        retvalr = Sundials.IDAGetRootInfo(mem, pointer(rootsfound))
         println("roots = ", rootsfound)
     end
-    if retval == Sundials.IDA_SUCCESS 
+    if retval == Sundials.IDA_SUCCESS
         iout += 1
         tout *= 10.0
     end
     if iout == nout break end
 end
-


### PR DESCRIPTION
The three fixed examples threw errors.  One errors were:
```
ERROR: LoadError: MethodError: `CVodeRootInit` has no method matching CVodeRootInit(::Ptr{Void}, ::Int32, ::Ptr{Void})
Closest candidates are:
  CVodeRootInit(::Ptr{Void}, !Matched::Int64, ::Ptr{Void})
```
```
ERROR: LoadError: MethodError: `CVDense` has no method matching CVDense(::Ptr{Void}, ::Int32)
Closest candidates are:
  CVDense(::Ptr{Void}, !Matched::Int64)
```
and
```
ERROR: LoadError: MethodError: `CVodeGetRootInfo` has no method matching CVodeGetRootInfo(::Ptr{Void}, ::Array{Int32,1})
Closest candidates are:
  CVodeGetRootInfo(::Ptr{Void}, !Matched::Ptr{Int32})
```
Same for IDA.  Someone who knows about calling C should check this, as I don't.  Also this is on a 64-bit system, maybe this needs to be different on 32-bit?

Also fixed some deprecations in ida_Cable.jl. 