### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ os:
     - linux
 julia:
     - 0.4
+    - 0.5
     - nightly
 notifications:
     email: false
-script:
-    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'Pkg.clone(pwd()); Pkg.build("Sundials"); Pkg.test("Sundials"; coverage=true)';
+#script: # use the default script which does the following
+#    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#    - julia -e 'Pkg.clone(pwd()); Pkg.build("Sundials"); Pkg.test("Sundials"; coverage=true)';
 after_success:
     - julia -e 'cd(Pkg.dir("Sundials")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
-julia 0.4-
+julia 0.4
 BinDeps 0.3
+Compat

--- a/src/wrap_sundials.jl
+++ b/src/wrap_sundials.jl
@@ -2,12 +2,12 @@
 # that uses the Clang.jl package to wrap Sundials using the headers.
 
 # Find all headers
-incpath = Pkg.dir("Sundials", "deps", "usr", "include")
+incpath = joinpath(dirname(@__FILE__), "..", "deps", "usr", "include")
 if !isdir(incpath)
   error("Run Pkg.build(\"Sundials\") before trying to wrap C headers.")
 end
 
-wdir = Pkg.dir("Sundials", "new")
+wdir = joinpath(dirname(@__FILE__), "..", "new")
 mkpath(wdir)
 cd(wdir)
 


### PR DESCRIPTION
This allows installing the package elsewhere.

Add testing against 0.5 to Travis - this runs the most
recent RC now, release once final tags are done.

Add Compat to REQUIRE (used in sundials_h.jl) and drop support for prereleases of 0.4